### PR TITLE
recast matrix as vectors 

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -238,11 +238,11 @@ julia> convexity(0.03,my_lump_sum_value)
 ```
 """
 function duration(::Macaulay,yield,cfs,times)
-    return sum(times .* price.(yield,cfs,times) / price(yield,cfs,times))
+    return sum(times .* price.(yield,vec(cfs),times) / price(yield,vec(cfs),times))
 end
 
 function duration(::Modified,yield,cfs,times)
-    return duration(yield,i -> price(i,cfs,times))
+    return duration(yield,i -> price(i,vec(cfs),times))
 end
 
 function duration(yield,valuation_function)
@@ -258,19 +258,19 @@ function duration(yield::Yields.YieldCurve,valuation_function)
 end
 
 function duration(yield,cfs,times)
-    return duration(Modified(),yield,cfs,times)
+    return duration(Modified(),yield,vec(cfs),times)
 end
 function duration(yield,cfs::A) where {A <: AbstractArray}
     times = 1:length(cfs)
-    return duration(Modified(),yield,cfs,times)
+    return duration(Modified(),yield,vec(cfs),times)
 end
 
 function duration(::DV01,yield,cfs,times)
-    return duration(DV01(),yield,i->price(i,cfs,times))
+    return duration(DV01(),yield,i->price(i,vec(cfs),times))
 end
 function duration(d::Duration,yield,cfs)
     times = 1:length(cfs)
-    return duration(d,yield,cfs,times)
+    return duration(d,yield,vec(cfs),times)
 end
 
 function duration(::DV01,yield,valuation_function)
@@ -316,11 +316,11 @@ julia> convexity(0.03,my_lump_sum_value)
 
 """
 function convexity(yield,cfs,times)
-    return convexity(yield, i -> price(i,cfs,times))
+    return convexity(yield, i -> price(i,vec(cfs),times))
 end
 function convexity(yield,cfs::A) where {A <: AbstractArray}
     times = 1:length(cfs)
-    return convexity(yield, i -> price(i,cfs,times))
+    return convexity(yield, i -> price(i,vec(cfs),times))
 end
 
 function convexity(yield,valuation_function)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,7 +174,7 @@ end
     end
 end
 
-@testset "duration" begin
+@testset "duration and convexity" begin
     
     @testset "wikipedia example" begin
         times = [0.5,1,1.5,2]
@@ -233,6 +233,21 @@ end
         @test duration(Macaulay(), 0.03, cfs) ≈ 2.863504670671131
         @test duration(0.03, cfs) ≈ 2.780101622010806
         @test convexity(0.03, cfs) ≈ 10.62580548268594
+
+
+        # test a single matrix dimension
+        cfs = [5 0 0
+               0 5 105]
+
+        @test duration(0.03, sum(cfs,dims=1), times) ≈ 2.780101622010806
+
+        cfs = [5 0
+               5 0 
+               0 105]
+
+        @test duration(0.03, sum(cfs,dims=2), times) ≈ 2.780101622010806
+
+
     end
 
 end


### PR DESCRIPTION
(useful when you've summed a matrix by one of the dimensions)

Like before, passing a mxn matrix wil produce a nonsense result, but now a 1xn or mx1 matrix will work fine.