### PR TITLE
Improve performance of present value functions

### DIFF
--- a/src/ActuaryUtilities.jl
+++ b/src/ActuaryUtilities.jl
@@ -9,7 +9,12 @@ import StatsBase
 
 include("financial_math.jl")
 include("risk_measures.jl")
-include("precompile.jl")
+
+# https://timholy.github.io/SnoopCompile.jl/stable/snoopi_deep_parcel/
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
 
 
 """

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -113,11 +113,11 @@ present_value(0.1, [10,20],times)
 
 """
 function present_value(yc::T, cashflows, timepoints) where {T <: Yields.AbstractYield}
-    sum(discount.(yc, timepoints) .* cashflows)
+    sum(discount(yc,t) * cf for (t,cf) in zip(timepoints, cashflows))
 end
 
 function present_value(yc::T, cashflows) where {T <: Yields.AbstractYield}
-    sum(discount.(yc, 1:length(cashflows)) .* cashflows)
+    present_value(yc,cashflows,1:length(cashflows))
 end
 
 function present_value(i, x)
@@ -140,13 +140,13 @@ end
 # Interest Given is an array, assume forwards.
 function present_value(i::AbstractArray, v)
     yc = Yields.Forward(i)
-    return sum(discount(yc, t) * v[t] for t in 1:length(v))
+    return sum(discount(yc, t) * cf for (t,cf) in zip(1:length(v),v))
 end
 
 # Interest Given is an array, assume forwards.
 function present_value(i::AbstractArray, v, times)
     yc = Yields.Forward(i, times)
-    return sum(discount(yc, t) * v[i] for (i, t) in enumerate(times))
+    return sum(discount(yc, t) * cf for (cf, t) in zip(v,times))
 end
 
 """

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -120,9 +120,17 @@ function present_value(yc::T, cashflows) where {T <: Yields.AbstractYield}
     sum(discount.(yc, 1:length(cashflows)) .* cashflows)
 end
 
-function present_value(i, v)
-    yc = Yields.Constant(i)
-    return sum(discount(yc, t) * v[t] for t in 1:length(v))
+function present_value(i, x)
+    
+    v = 1.0
+    v_factor = 1/(1+i)
+    pv = 0.0
+
+    for (t,cf) in zip(1:length(x),x)
+        v *= v_factor
+        pv += v * cf
+    end
+    return pv 
 end
 
 function present_value(i, v, times)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,11 +1,21 @@
+
+# created with the help of SnoopCompile.jl
 function _precompile_()
-    precompile(irr,(Vector{Float64},UnitRange{Int64}))
-    precompile(irr,(Vector{Float64},Vector{Int64}))
-    precompile(irr,(Vector{Float64},Vector{Float64}))
-    precompile(irr,(Vector{Int},Vector{Int}))
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    Base.precompile(Tuple{typeof(internal_rate_of_return),Vector{Int64}})   
+    Base.precompile(Tuple{typeof(internal_rate_of_return),Vector{Float64}})
+    Base.precompile(Tuple{typeof(internal_rate_of_return),Vector{Int64},Vector{Float64}})
+    Base.precompile(Tuple{typeof(internal_rate_of_return),Vector{Float64},Vector{Float64}})   
+
+
+    Base.precompile(Tuple{typeof(present_value),Float64,Vector{Int64},Vector{Float64}}) 
+    Base.precompile(Tuple{typeof(present_value),Float64,Vector{Float64},Vector{Float64}}) 
+    Base.precompile(Tuple{typeof(present_value),Float64,Vector{Float64},Vector{Int64}}) 
+
+    Base.precompile(Tuple{typeof(duration),Float64,Vector{Float64}})
+    Base.precompile(Tuple{typeof(duration),Float64,Vector{Int64}})
+
+    Base.precompile(Tuple{typeof(convexity),Float64,Vector{Float64}})
+    Base.precompile(Tuple{typeof(convexity),Float64,Vector{Int64}})
     
-    precompile(present_value,(Float64,Vector{Float64}))
-    precompile(present_value,(Float64,Vector{Float64},Vector{Float64}))
-
-
 end


### PR DESCRIPTION
of the most basic `pv(rate,cfs)`:
```julia-repl
julia> judge(median(new),median(old))
BenchmarkTools.TrialJudgement:
  time:   -98.85% => improvement (5.00% tolerance)
  memory: -98.98% => improvement (1.00% tolerance)
  ```