### PR TITLE
Functions which return rates (e.g. `irr`) now return a `Yields.Rate` object (periodic once per period)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "c:\\Users\\alecl\\.julia\\dev\\ActuaryUtilities"
+}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ActuaryUtilities"
 uuid = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 authors = ["Alec Loudenback"]
-version = "2.11.0"
+version = "3.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 ![CI](https://github.com/JuliaActuary/ActuaryUtilities.jl/workflows/CI/badge.svg)
 [![Codecov](https://codecov.io/gh/JuliaActuary/ActuaryUtilities.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaActuary/ActuaryUtilities.jl)
 
+## Quickstart
+
+```julia
+cfs = [5, 5, 105]
+times    = [1, 2, 3]
+
+discount_rate = 0.03
+
+present_value(discount_rate, cfs, times)           # 105.65
+duration(Macaulay(), discount_rate, cfs, times)    #   2.86
+duration(discount_rate, cfs, times)                #   2.78
+convexity(discount_rate, cfs, times)               #  10.62
+```
+
 ## Features
 
 A collection of common functions/manipulations used in Actuarial Calculations.
@@ -19,13 +33,13 @@ A collection of common functions/manipulations used in Actuarial Calculations.
 - `breakeven` to calculate the breakeven time for a set of cashflows
 - `accum_offset` to calculate accumulations like survivorship from a mortality vector
 
-#### Options Pricing
+### Options Pricing
 - `eurocall` and `europut` for Black-Scholes option prices
 
 ### Risk Measures
 
-- Calculate risk measures for a given vector of risks: 
-  - `CTE` for the Conditiona Tail Expectation, or 
+- Calculate risk measures for a given vector of risks:
+  - `CTE` for the Conditiona Tail Expectation, or
   - `VaR` for the percentile/Value at Risk.
 
 ### Insurance mechanics
@@ -33,41 +47,49 @@ A collection of common functions/manipulations used in Actuarial Calculations.
 - `duration`:
   - Calculate the duration given an issue date and date (a.k.a. policy duration)
   
-### Excel Utilities
 
-Copying data to/and from the clipboard was previously built-in to ActuaryUtilities vesions `1.3` and lower. The features have been moved to [ClipData](https://github.com/pdeffebach/ClipData.jl). Usage to copy tabular data (e.g. from spreadsheets):
+### Typed Rates
 
-```julia
-using ClipData
-cliptable() # copy data from the clipboard with headers
-cliptable(data) # copy tabular data to the clipboard for spreadsheet usage
-clipdata() # copy array/matrix (headerless) data to Julia
-clipdata(data) # copy array data to the clipboard
+- functions which return a rate/yield will return a `Yields.Rate` object. E.g. `irr(cashflows)` will return a `Rate(0.05,Periodic(1))` instead of just a `0.05` (`float64`) to convey the compounding frequency. This uses (and is fully compatible with) Yields.jl and can be used anywhere you would otherwise use a simple floating point rate.
+
+A couple of other notes:
+
+- `rate(...)` will return the untyped rate from a `Yields.Rate` struct:
+
+```julia-repl
+julia> r = Yields.Rate(0.05,Yields.Periodic(1));
+
+julia> rate(r) 
+0.05
 ```
 
-The old `xlclip` does the same thing `clipdata()` does.
+- You can still pass a simple floating point rate to various methods. E.g. these two are the same (the default compounding convention is periodic once per period):
 
-https://user-images.githubusercontent.com/711879/116340294-8c954500-a7a4-11eb-9159-cc9dc3fda80a.mp4
+```julia
+discount(0.05,cashflows)
+
+r = Yields.Rate(0.05,Yields.Periodic(1));
+discount(r,cashflows)
+```
+
+- convert between rates with:
+
+```julia
+using Yields
+
+r = Yields.Rate(0.05,Yields.Periodic(1));
+
+convert(Yields.Periodic(2),  r)   # convert to compounded twice per timestep
+convert(Yields.Continuous(2),r)   # convert to compounded twice per timestep
+```
+
+For more, see the [Yields.jl](https://github.com/JuliaActuary/Yields.jl) which provides a rich and flexible API for rates and curves to use.
 
 ## Documentation
 
 Full documentation is [available here](https://JuliaActuary.github.io/ActuaryUtilities.jl/stable/).
 
 ## Examples
-
-### Quickstart 
-
-```julia
-cfs = [5, 5, 105]
-times    = [1, 2, 3]
-
-discount_rate = 0.03
-
-present_value(discount_rate, cfs, times)           # 105.65
-duration(Macaulay(), discount_rate, cfs, times)    #   2.86
-duration(discount_rate, cfs, times)                #   2.78
-convexity(discount_rate, cfs, times)               #  10.62
-```
 
 ### Interactive, basic cashflow analysis
 
@@ -79,4 +101,4 @@ See [JuliaActuary.org for instructions](https://juliaactuary.org/tutorials/cashf
 
 ## Useful tips
 
-Functions often use a mix of interest_rates, cashflows, and timepoints. When calling functions, the general order of the arguments is 1) interest rates, 2) cashflows, and 3) timepoints. 
+Functions often use a mix of interest_rates, cashflows, and timepoints. When calling functions, the general order of the arguments is 1) interest rates, 2) cashflows, and 3) timepoints.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ import DayCounts
 include("risk_measures.jl")
 include("derivatives.jl")
 
+#convenience function to wrap scalar into default Rate type
+p(rate) = Yields.Periodic(rate,1)
+
 @testset "Temporal functions" begin
     @testset "years_between" begin
         @test years_between(Date(2018, 9, 30), Date(2018, 9, 30)) == 0
@@ -110,12 +113,12 @@ end
         v = [-70000,12000,15000,18000,21000,26000]
         
         # per Excel (example comes from Excel help text)
-        @test isapprox(irr(v[1:2]), -0.8285714285714, atol = 0.001)
-        @test isapprox(ActuaryUtilities.irr(v[1:2]), -0.8285714285714, atol = 0.001)
-        @test isapprox(ActuaryUtilities.irr(v[1:3]), -0.4435069413346, atol = 0.001)
-        @test isapprox(irr(v[1:4]), -0.1821374641455, atol = 0.001)
-        @test isapprox(irr(v[1:5]), -0.0212448482734, atol = 0.001)
-        @test isapprox(irr(v[1:6]),  0.0866309480365, atol = 0.001)
+        @test isapprox(irr(v[1:2]), p(-0.8285714285714), atol = 0.001)
+        @test isapprox(ActuaryUtilities.irr(v[1:2]), p(-0.8285714285714), atol = 0.001)
+        @test isapprox(ActuaryUtilities.irr(v[1:3]), p(-0.4435069413346), atol = 0.001)
+        @test isapprox(irr(v[1:4]), p(-0.1821374641455), atol = 0.001)
+        @test isapprox(irr(v[1:5]), p(-0.0212448482734), atol = 0.001)
+        @test isapprox(irr(v[1:6]),  p(0.0866309480365), atol = 0.001)
 
         @test_throws MethodError irr("hello") 
 
@@ -123,14 +126,14 @@ end
         # much more challenging to solve b/c of the overflow below zero
         cfs = [t % 10 == 0 ? -10 : 1.5 for t in 0:99]
 
-        @test isapprox(irr(cfs), 0.06463163963925866, atol = 0.001)
+        @test isapprox(irr(cfs), p(0.06463163963925866), atol = 0.001)
 
         # issue #28
         cfs = [-8.728037307132952e7, 3.043754023830998e7, 2.963004184784189e7, 2.8803030748755097e7, 2.7956912111811966e7, 2.7092182051244527e7, 2.6209069543806538e7, 2.5307964329840004e7, 2.438961041057478e7, 2.3455084653011695e7, 2.2505925520018265e7, 2.154395414765592e7, 2.0571076113065004e7, 1.958930608135183e7, 1.8600627464895025e7, 1.7606980923262402e7, 1.661046149512893e7, 1.561312825963898e7, 1.461760481586352e7, 1.3626801207410209e7, 1.2644733969499402e7, 1.1675393687299855e7, 1.0722720151658386e7, 9.79075673433771e6, 8.883278741880089e6, 8.004445298876338e6, 7.1588010859461725e6, 6.351121678665243e6, 5.585860320479795e6, 4.8673895159943625e6, 4.19908059495347e6, 3.583538247530099e6, 3.022766488834396e6, 2.5181072324190177e6, 2.0701053881076649e6, 1.6782921224664208e6, 1.3410605489291362e6, 1.0556643097527474e6, 818348.5357315112, 624147.9373214925, 467849.788997191, 344241.752520618, 248285.65630649775, 175235.5475426321, 120677.87174498942, 80759.09804678289, 52186.83400936739, 32211.057718402008, 18589.51907385164, 9540.782278174447, 3688.4015341755294]
-        @test irr(cfs,0:50) ≈ 0.3176680627111823
+        @test irr(cfs,0:50) ≈ p(0.3176680627111823)
 
 
-        @test irr([-100,100]) ≈ 0.
+        @test irr([-100,100]) ≈ p(0.)
         @test isnothing(irr([100,100])) # answer is -1, but search range won't find it
         
         # test the unsolvable
@@ -143,27 +146,27 @@ end
         @test irr1 ≈ irr([-10,5,5,5])
         irr2 = irr([-10,5,5,5],[0,1,2,3] ./ 2)
 
-        @test (1+irr1)^2-1 ≈ irr2 
+        @test (1+Yields.rate(irr1))^2-1 ≈ Yields.rate(irr2)
 
     end
 
     @testset "numpy examples" begin
 
-        @test isapprox(irr([-150000, 15000, 25000, 35000, 45000, 60000]),  0.0524,     atol = 1e-4)
-        @test isapprox(irr([-100, 0, 0, 74]), -0.0955,     atol = 1e-4)
-        @test isapprox(irr([-100, 39, 59, 55, 20]),  0.28095,    atol = 1e-4)
-        @test isapprox(irr([-100, 100, 0, -7]), -0.0833,     atol = 1e-4)
-        @test isapprox(irr([-100, 100, 0, 7]),  0.06206,    atol = 1e-4)
+        @test isapprox(irr([-150000, 15000, 25000, 35000, 45000, 60000]),  p(0.0524),     atol = 1e-4)
+        @test isapprox(irr([-100, 0, 0, 74]), p(-0.0955),     atol = 1e-4)
+        @test isapprox(irr([-100, 39, 59, 55, 20]),  p(0.28095),    atol = 1e-4)
+        @test isapprox(irr([-100, 100, 0, -7]), p(-0.0833),     atol = 1e-4)
+        @test isapprox(irr([-100, 100, 0, 7]),  p(0.06206),    atol = 1e-4)
 
         # this has multiple roots, of which 0.709559 and 0.0886. Want to find the one closer to zero
-        @test isapprox(irr([-5, 10.5, 1, -8, 1]),  0.0886,     atol = 1e-4)
+        @test isapprox(irr([-5, 10.5, 1, -8, 1]),  p(0.0886),     atol = 1e-4)
     end
 
     @testset "xirr with float times" begin
 
     
-        @test isapprox(irr([-100,100], [0,1]), 0.0, atol = 0.001)
-        @test isapprox(irr([-100,110], [0,1]), 0.1, atol = 0.001)
+        @test isapprox(irr([-100,100], [0,1]), p(0.0), atol = 0.001)
+        @test isapprox(irr([-100,110], [0,1]), p(0.1), atol = 0.001)
 
     end
 
@@ -173,11 +176,11 @@ end
         dates = Date(2019, 12, 31):Year(1):Date(2024, 12, 31)
         times = map(d->DayCounts.yearfrac(dates[1], d, DayCounts.Thirty360()), dates)
     # per Excel (example comes from Excel help text)
-        @test isapprox(irr(v[1:2], times[1:2]), -0.8285714285714, atol = 0.001)
-        @test isapprox(ActuaryUtilities.irr_robust(v[1:3], times[1:3]), -0.4435069413346, atol = 0.001)
-        @test isapprox(irr(v[1:4], times[1:4]), -0.1821374641455, atol = 0.001)
-        @test isapprox(irr(v[1:5], times[1:5]), -0.0212448482734, atol = 0.001)
-        @test isapprox(irr(v[1:6], times[1:6]),  0.0866309480365, atol = 0.001)
+        @test isapprox(irr(v[1:2], times[1:2]), p(-0.8285714285714), atol = 0.001)
+        @test isapprox(ActuaryUtilities.irr_robust(v[1:3], times[1:3]), p(-0.4435069413346), atol = 0.001)
+        @test isapprox(irr(v[1:4], times[1:4]), p(-0.1821374641455), atol = 0.001)
+        @test isapprox(irr(v[1:5], times[1:5]), p(-0.0212448482734), atol = 0.001)
+        @test isapprox(irr(v[1:6], times[1:6]),  p(0.0866309480365), atol = 0.001)
 
     end
 end


### PR DESCRIPTION
Ref: https://github.com/JuliaActuary/Yields.jl/issues/79#issuecomment-1023824984