### PR TITLE
add `KeyRateZero` and `KeyRatePar` durations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ ForwardDiff = "^0.10"
 QuadGK = "^2"
 Roots = "^1.0"
 StatsBase = "^0.33"
-Yields = "^1.0"
+Yields = "^1.1"
 julia = "^1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A collection of common functions/manipulations used in Actuarial Calculations.
 
 - `duration`:
   - Calculate the `Macaulay`, `Modified`, or `DV01` durations for a set of cashflows
-  - Calculate the `KeyRate(time)` duration (note: API may change for this in future)
+  - Calculate the `KeyRate(time)` (a.k.a. `KeyRateZero`)duration or `KeyRatePar(time)` duration
 - `convexity` for price sensitivity
 - Flexible interest rate options via the [`Yields.jl`](https://github.com/JuliaActuary/Yields.jl) package.
 - `internal_rate_of_return` or `irr` to calculate the IRR given cashflows (including at timepoints like Excel's `XIRR`)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A collection of common functions/manipulations used in Actuarial Calculations.
 
 - `duration`:
   - Calculate the `Macaulay`, `Modified`, or `DV01` durations for a set of cashflows
+  - Calculate the `KeyRate(time)` duration (note: API may change for this in future)
 - `convexity` for price sensitivity
 - Flexible interest rate options via the [`Yields.jl`](https://github.com/JuliaActuary/Yields.jl) package.
 - `internal_rate_of_return` or `irr` to calculate the IRR given cashflows (including at timepoints like Excel's `XIRR`)
@@ -34,7 +35,7 @@ A collection of common functions/manipulations used in Actuarial Calculations.
 - `accum_offset` to calculate accumulations like survivorship from a mortality vector
 
 ### Options Pricing
-- `eurocall` and `europut` for Black-Scholes option prices
+- `eurocall` and `europut` for Black-Scholes option prices (note: API may change for this in future)
 
 ### Risk Measures
 

--- a/src/ActuaryUtilities.jl
+++ b/src/ActuaryUtilities.jl
@@ -152,7 +152,7 @@ export years_between, duration,
     pv, present_value, price, present_values,
     breakeven,moic,
     accum_offset,
-    Macaulay,Modified,DV01,KeyRatePar,KeyRateZero,duration, convexity,
+    Macaulay,Modified,DV01,KeyRatePar,KeyRateZero,KeyRate,duration, convexity,
     VaR,ValueAtRisk,CTE,ConditionalTailExpectation,ExpectedShortfall,
     eurocall, europut
 

--- a/src/ActuaryUtilities.jl
+++ b/src/ActuaryUtilities.jl
@@ -152,7 +152,7 @@ export years_between, duration,
     pv, present_value, price, present_values,
     breakeven,moic,
     accum_offset,
-    Macaulay,Modified,DV01,KeyRate,duration, convexity,
+    Macaulay,Modified,DV01,KeyRatePar,KeyRateZero,duration, convexity,
     VaR,ValueAtRisk,CTE,ConditionalTailExpectation,ExpectedShortfall,
     eurocall, europut
 

--- a/src/ActuaryUtilities.jl
+++ b/src/ActuaryUtilities.jl
@@ -152,7 +152,7 @@ export years_between, duration,
     pv, present_value, price, present_values,
     breakeven,moic,
     accum_offset,
-    Macaulay,Modified,DV01,duration, convexity,
+    Macaulay,Modified,DV01,KeyRate,duration, convexity,
     VaR,ValueAtRisk,CTE,ConditionalTailExpectation,ExpectedShortfall,
     eurocall, europut
 

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -481,15 +481,18 @@ in practice, but that the zero curve produces more consistent results. Future ve
 
 References: 
 - [Quant Finance Stack Exchange: To compute key rate duration, shall I use par curve or zero curve?](https://quant.stackexchange.com/questions/33891/to-compute-key-rate-duration-shall-i-use-par-curve-or-zero-curve)
-
+- (Financial Exam Help 123](http://www.financialexamhelp123.com/key-rate-duration/)
 
 """
 function duration(keyrate::KeyRateDuration, curve, cashflows, timepoints, krd_points; shift = 0.0001)
-    new_curve = _krd_new_curve(keyrate,curve,krd_points)
+    curve_up = _krd_new_curve(keyrate,curve,krd_points;shift)
+    curve_down = _krd_new_curve(keyrate,curve,krd_points;shift=-shift)
     price = pv(curve, cashflows, timepoints)
-    price_shock = pv(new_curve, cashflows, timepoints)
+    price_up = pv(curve_up, cashflows, timepoints)
+    price_down = pv(curve_down, cashflows, timepoints)
+    
 
-    return -(price_shock - price) / (shift * price)
+    return (price_down - price_up) / (2*shift*price)
 
 end
 

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -499,7 +499,9 @@ function _krd_new_curve(keyrate::KeyRateZero,curve,krd_points;shift)
 
     zero_index = findfirst(==(keyrate.timepoint), curve_times)
 
-    zeros[zero_index] += shift
+    target_rate = pars[zero_index]
+
+    zeros[zero_index] += Yields.Rate(shift,target_rate.compounding)
 
     new_curve = Yields.Zero(zeros, curve_times)
 
@@ -508,13 +510,14 @@ end
 
 function _krd_new_curve(keyrate::KeyRatePar,curve,krd_points;shift)
     curve_times = krd_points
-    zeros = Yields.par.(curve, curve_times)
+    pars = Yields.par.(curve, curve_times)
 
     zero_index = findfirst(==(keyrate.timepoint), curve_times)
 
-    zeros[zero_index] += shift
+    target_rate = pars[zero_index]
+    pars[zero_index] += Yields.Rate(shift,target_rate.compounding)
 
-    new_curve = Yields.Par(zeros, curve_times)
+    new_curve = Yields.Par(pars, curve_times)
 
     return new_curve
 end

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -484,14 +484,14 @@ end
 
 
 """
-    duration(keyrate::KeyRate,curve,cashflows; shift=0.01)    
-    duration(keyrate::KeyRate,curve,cashflows,timepoints; shift=0.01)
-    duration(keyrate::KeyRate,curve,cashflows,timepoints,krd_points; shift=0.01)
+    duration(keyrate::KeyRateDuration,curve,cashflows)    
+    duration(keyrate::KeyRateDuration,curve,cashflows,timepoints)
+    duration(keyrate::KeyRateDuration,curve,cashflows,timepoints,krd_points)
 
-Calculate the key rate duration by shifting the **zero** (not par) curve by the kwarg `shift` at the timepoint specified by a KeyRate(time).
+Calculate the key rate duration by shifting the **zero** (not par) curve by the kwarg `shift` at the timepoint specified by a KeyRateDuration(time).
 
 The approach is to carve up the curve into `krd_points` (default is the unit steps between `1` and  the last timepoint of the casfhlows). The 
-zero rate corresponding to the timepoint within the `KeyRate` is shifted by `shift` and a new curve is created from the new spot rates. This means that the 
+zero rate corresponding to the timepoint within the `KeyRateDuration` is shifted by `shift` (specified by the `KeyRateZero` or `KeyRatePar` constructors. A new curve is created from the shifted rates. This means that the 
 "width" of the shifted section is ± 1 time period, unless specific points are specified via `krd_points`.
 
 The `curve` may be any Yields.jl curve (e.g. does not have to be a curve constructed via `Yields.Zero(...)`).

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -549,7 +549,7 @@ function _krd_new_curve(keyrate::KeyRateZero,curve,krd_points)
 
     zero_index = findfirst(==(keyrate.timepoint), curve_times)
 
-    target_rate = pars[zero_index]
+    target_rate = zeros[zero_index]
 
     zeros[zero_index] += Yields.Rate(shift,target_rate.compounding)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -317,11 +317,22 @@ end
 
             c = Yields.Constant(0.04)
 
+            # cn = curve, new
             cn = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10;shift=0.005)
 
             @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.005
-            @test Yields.spot(cn,4) ≈ Yields.Periodic(0.04,1)            
-            @test Yields.spot(cn,5)             
+            @test Yields.zero(cn,4) ≈ Yields.Periodic(0.04,1)            
+            @test Yields.zero(cn,5) > Yields.par(cn,5)
+
+            bond = parbond(0.04,5)
+
+            @test duration(KeyRatePar(1),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
+            @test duration(KeyRatePar(2),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
+            @test duration(KeyRatePar(3),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
+            @test duration(KeyRatePar(4),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
+            @test duration(KeyRatePar(5),Yields.Constant(0.04),bond.cfs,bond.times) > 0.0
+
+
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,22 +309,28 @@ end
     end
 
     @testset "Key Rate Durations" begin
+        default_shift = 0.001
+
+        @test KeyRate(5) == KeyRateZero(5)
+        @test KeyRate(5) == KeyRateZero(5,default_shift)
+        @test KeyRatePar(5) == KeyRatePar(5,default_shift)
+        
+        c = Yields.Constant(Yields.Periodic(0.04,2))
+
+        cp = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10)
+        cz = ActuaryUtilities._krd_new_curve(KeyRateZero(5),c,1:10)
+
+        # test some relationships between par and zero curve
+        @test Yields.par(cp,5) ≈ Yields.par(c,5) + default_shift atol = 0.0002 # 0.001 is the default shift
+        @test Yields.par(cp,4) ≈ Yields.Periodic(0.04,2) atol = 0.0001           
+        @test Yields.zero(cp,5) > Yields.par(cp,5)
+        @test Yields.zero(cp,6) < Yields.par(cp,6)
 
         @testset "FEH123" begin
             # http://www.financialexamhelp123.com/key-rate-duration/
 
             #test some curve properties
 
-            c = Yields.Constant(Yields.Periodic(0.04,2))
-
-            # cn = curve, new
-            cn = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10)
-
-            # test some relationships between par and zero curve
-            @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.001 atol = 0.0002 # 0.001 is the default shift
-            @test Yields.par(cn,4) ≈ Yields.Periodic(0.04,2) atol = 0.0001           
-            @test Yields.zero(cn,5) > Yields.par(cn,5)
-            @test Yields.zero(cn,6) < Yields.par(cn,6)
 
             bond = parbond(0.04,5)
 
@@ -333,8 +339,14 @@ end
             @test duration(KeyRatePar(3),c,bond.cfs,bond.times) ≈ 0.0 atol = 0.002
             @test duration(KeyRatePar(4),c,bond.cfs,bond.times) ≈ 0.0 atol = 0.002
             @test duration(KeyRatePar(5),c,bond.cfs,bond.times) ≈ 4.45 atol = 0.05
-
-
+            
+            bond =(times=[1,2,3,4,5],cfs=[0,0,0,0,100])
+            @test duration(KeyRateZero(1),c,bond.cfs,bond.times) ≈ 0.0 
+            @test duration(KeyRateZero(2),c,bond.cfs,bond.times) ≈ 0.0 
+            @test duration(KeyRateZero(3),c,bond.cfs,bond.times) ≈ 0.0 
+            @test duration(KeyRateZero(4),c,bond.cfs,bond.times) ≈ 0.0 
+            @test duration(KeyRateZero(5),c,bond.cfs,bond.times) ≈ duration(c,bond.cfs,bond.times) atol = 0.1
+            
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ const Yields = ActuaryUtilities.Yields
 
 import DayCounts
 
+include("test_utils.jl")
 include("risk_measures.jl")
 include("derivatives.jl")
 
@@ -305,6 +306,26 @@ end
         @test duration(0.03, sum(cfs,dims=2), times) ≈ 2.780101622010806
 
 
+    end
+
+    @testset "Key Rate Durations" begin
+
+        @testset "FEH123" begin
+            # http://www.financialexamhelp123.com/key-rate-duration/
+
+            #test some curve properties
+
+            c = Yields.Constant(0.04)
+
+            cn = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10;shift=0.005)
+
+            @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.005
+            @test Yields.spot(cn,4) ≈ Yields.Periodic(0.04,1)            
+            @test Yields.spot(cn,5)             
+
+
+
+        end
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -315,22 +315,24 @@ end
 
             #test some curve properties
 
-            c = Yields.Constant(0.04)
+            c = Yields.Constant(Yields.Periodic(0.04,2))
 
             # cn = curve, new
             cn = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10;shift=0.005)
 
-            @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.005
-            @test Yields.zero(cn,4) ≈ Yields.Periodic(0.04,1)            
+            # test some relationships between par and zero curve
+            @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.005 atol = 0.0002
+            @test Yields.par(cn,4) ≈ Yields.Periodic(0.04,2) atol = 0.0001           
             @test Yields.zero(cn,5) > Yields.par(cn,5)
+            @test Yields.zero(cn,6) < Yields.par(cn,6)
 
             bond = parbond(0.04,5)
 
-            @test duration(KeyRatePar(1),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
-            @test duration(KeyRatePar(2),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
-            @test duration(KeyRatePar(3),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
-            @test duration(KeyRatePar(4),Yields.Constant(0.04),bond.cfs,bond.times) ≈ 0.0 atol = 0.001
-            @test duration(KeyRatePar(5),Yields.Constant(0.04),bond.cfs,bond.times) > 0.0
+            @test duration(KeyRatePar(1),c,bond.cfs,bond.times) ≈ 0.0 atol = 0.01
+            @test duration(KeyRatePar(2),c,bond.cfs,bond.times) ≈ 0.0 atol = 0.002
+            @test duration(KeyRatePar(3),c,bond.cfs,bond.times) ≈ 0.0 atol = 0.002
+            @test duration(KeyRatePar(4),c,bond.cfs,bond.times) ≈ 0.0 atol = 0.002
+            @test duration(KeyRatePar(5),c,bond.cfs,bond.times) ≈ 4.45 atol = 0.05
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,10 +318,10 @@ end
             c = Yields.Constant(Yields.Periodic(0.04,2))
 
             # cn = curve, new
-            cn = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10;shift=0.005)
+            cn = ActuaryUtilities._krd_new_curve(KeyRatePar(5),c,1:10)
 
             # test some relationships between par and zero curve
-            @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.005 atol = 0.0002
+            @test Yields.par(cn,5) ≈ Yields.par(c,5) + 0.001 atol = 0.0002 # 0.001 is the default shift
             @test Yields.par(cn,4) ≈ Yields.Periodic(0.04,2) atol = 0.0001           
             @test Yields.zero(cn,5) > Yields.par(cn,5)
             @test Yields.zero(cn,6) < Yields.par(cn,6)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,10 +1,10 @@
 """
     parbond(yield,term; par = 100)
-The `times` and `cfs` in a named tuple for a bond paying semi-annual coupons with the given `yield` and `par` over the `term` (in integer years).
+The `times` and `cfs` in a named tuple for a bond paying semi-annual coupons with the given `yield` (assume annual effective if not specified) and `par` over the `term` (in integer years).
 """
-function parbond(yield, term; par=100)
+function parbond(yield::Yields.Rate, term; par=100.)
     r = convert(Yields.Periodic(2), yield)
-    coupon = rate(r) / 2
+    coupon = Yields.rate(r) / 2
     times = 0.5:0.5:term
     cfs = map(times) do t
         if t == term
@@ -15,4 +15,9 @@ function parbond(yield, term; par=100)
     end
 
     (; times, cfs)
+end
+
+function parbond(yield::T,term; par=100.) where {T<:Real}
+    y = Yields.Periodic(yield,1)
+    return parbond(y,term;par)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,18 @@
+"""
+    parbond(yield,term; par = 100)
+The `times` and `cfs` in a named tuple for a bond paying semi-annual coupons with the given `yield` and `par` over the `term` (in integer years).
+"""
+function parbond(yield, term; par=100)
+    r = convert(Yields.Periodic(2), yield)
+    coupon = rate(r) / 2
+    times = 0.5:0.5:term
+    cfs = map(times) do t
+        if t == term
+            return par + par * coupon
+        else
+            return par * coupon
+        end
+    end
+
+    (; times, cfs)
+end


### PR DESCRIPTION
closes #24

doesn't have any tests - need to find examples. See docstring for comments (copied here):

```
    duration(keyrate::KeyRate,curve,cashflows; shift=0.01)    
    duration(keyrate::KeyRate,curve,cashflows,timepoints; shift=0.01)
    duration(keyrate::KeyRate,curve,cashflows,timepoints,krd_points; shift=0.01)

Calculate the key rate duration by shifting the **zero** (not par) curve by the kwarg `shift` at the timepoint specified by a KeyRate(time).

The approach is to carve up the curve into `krd_points` (default is the unit steps between `1` and  the last timepoint of the casfhlows). The 
zero rate corresponding to the timepoint within the `KeyRate` is shifted by `shift` and a new curve is created from the new spot rates. This means that the 
"width" of the shifted section is ± 1 time period, unless specific points are specified via `krd_points`.

The `curve` may be any Yields.jl curve (e.g. does not have to be a curve constructed via `Yields.Zero(...)`).

!!! Experimental: Due to the paucity of examples in the literature, this feature does not have unit tests like the rest of JuliaActuary functionality. Additionally, the API may change in a future major/minor version update.
```

Example usage:

```julia-repl
julia> riskfree_maturities = [0.5, 1.0, 1.5, 2.0];

julia> riskfree    = [0.05, 0.058, 0.064,0.068];

julia> rf_curve = Yields.Zero(riskfree,riskfree_maturities);

julia> cfs = [10,10,10,10,10];

julia> duration(KeyRate(1),rf_curve,cfs)
8.932800152336995

```
