### PR TITLE
moic returns a string instead of NaN 

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -534,7 +534,8 @@ function moic(cfs::T) where {T<:AbstractArray}
     pos = cfs .> 0
     neg = cfs .< 0
     if !(any(pos) && any(neg))
-        return NaN
+        return "No Positive or Negative Values provided"
+    end
     returned = sum(cf for cf in cfs if cf > 0)
     invested = -sum(cf for cf in cfs if cf < 0)
     return returned / invested

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -531,6 +531,10 @@ julia> moic([-10,20,30])
 
 """
 function moic(cfs::T) where {T<:AbstractArray}
+    pos = cfs .> 0
+    neg = cfs .< 0
+    if !(any(pos) && any(neg))
+        return NaN
     returned = sum(cf for cf in cfs if cf > 0)
     invested = -sum(cf for cf in cfs if cf < 0)
     return returned / invested


### PR DESCRIPTION
When no Positive or Negative values are provided to the function `moic` it will return a string that No Positive or Negative values are Provided instead of returning `NaN`