### PR TITLE
Avoid duplicate CI runs

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -1,7 +1,8 @@
 name: CI
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [master]
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- Scopes `push` trigger to `master` branch only, so PRs only run CI once (via the `pull_request` event) instead of twice

Previously the bare `on: [push, pull_request]` caused every PR push to trigger two identical workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)