### PR TITLE
Update doc links to docs.juliaactuary.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ActuaryUtilities
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaActuary.github.io/ActuaryUtilities.jl/stable/) 
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaActuary.github.io/ActuaryUtilities.jl/dev/)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.juliaactuary.org/ActuaryUtilities/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://docs.juliaactuary.org/ActuaryUtilities/dev/)
 ![CI](https://github.com/JuliaActuary/ActuaryUtilities.jl/workflows/CI/badge.svg)
 [![Codecov](https://codecov.io/gh/JuliaActuary/ActuaryUtilities.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaActuary/ActuaryUtilities.jl)
 
@@ -67,7 +67,7 @@ hw_result = sensitivities(hw, cfs, tenors; n_scenarios=1000, rng=Xoshiro(42))
 hw_result.durations   # key rate durations under stochastic dynamics
 ```
 
-See the [Key Rate Sensitivities documentation](https://JuliaActuary.github.io/ActuaryUtilities.jl/stable/sensitivities/) for details.
+See the [Key Rate Sensitivities documentation](https://docs.juliaactuary.org/ActuaryUtilities/stable/sensitivities/) for details.
 
 ### Risk Measures
 
@@ -120,7 +120,7 @@ For more on Rates, see [FinanceCore.jl](https://github.com/JuliaActuary/FinanceC
 
 ## Documentation
 
-Full documentation is [available here](https://JuliaActuary.github.io/ActuaryUtilities.jl/stable/).
+Full documentation is [available here](https://docs.juliaactuary.org/ActuaryUtilities/stable/).
 
 ## Examples
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,7 +114,7 @@ For more on Rates, see [FinanceCore.jl](https://github.com/JuliaActuary/FinanceC
 
 ## Documentation
 
-Full documentation is [available here](https://JuliaActuary.github.io/ActuaryUtilities.jl/stable/).
+Full documentation is [available here](https://docs.juliaactuary.org/ActuaryUtilities/stable/).
 
 ## Examples
 

--- a/docs/src/sensitivities.md
+++ b/docs/src/sensitivities.md
@@ -393,7 +393,7 @@ zrc_aki = ZeroRateCurve(rates, tenors, Spline.Akima())           # Akima
 
 **Cubic spline** (`Spline.Cubic()`): Smoothest (C2), but bumps have non-local effects. KRDs at distant tenors may be negative. Use when smoothness matters most.
 
-See the [FinanceModels interpolation guide](https://juliaactuary.github.io/FinanceModels.jl/dev/interpolation/) for detailed benchmarks and tradeoff analysis. On a flat curve, all methods produce identical results.
+See the [FinanceModels interpolation guide](https://docs.juliaactuary.org/FinanceModels/dev/interpolation/) for detailed benchmarks and tradeoff analysis. On a flat curve, all methods produce identical results.
 
 ## Validating AD vs Bump-and-Reprice
 


### PR DESCRIPTION
## Summary
- Update documentation badge links in README and docs index to point to the unified `docs.juliaactuary.org` site instead of `JuliaActuary.github.io`
- Update inline documentation references (Key Rate Sensitivities docs, FinanceModels interpolation guide) to use the new URL

## Test plan
- [ ] Verify badge links resolve correctly to `https://docs.juliaactuary.org/ActuaryUtilities/stable/` and `/dev/`
- [ ] Verify the sensitivities doc cross-link to FinanceModels interpolation guide works

🤖 Generated with [Claude Code](https://claude.com/claude-code)