### PR TITLE
Fix KeyRateZero docstring errors

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -197,11 +197,11 @@ end
 """
     KeyRateZero(timepoint,shift=0.001) <: KeyRateDuration
 
-Shift the par curve by the given amount at the given timepoint. Use in conjunction with `duration` to calculate the key rate duration.
+Shift the zero curve by the given amount at the given timepoint. Use in conjunction with `duration` to calculate the key rate duration.
 
 Unlike other duration statistics which are computed using analytic derivatives, `KeyRateDuration` is computed via a shift-and-compute the yield curve approach.
 
-`KeyRateZero` is less commonly reported (than [`KeyRatePar`](@ref)) in the fixed income markets, even though the latter has more analytically attractive properties. See the discussion of KeyRateDuration in the FinanceModels.jl docs.
+`KeyRateZero` is less commonly reported (than [`KeyRatePar`](@ref)) in the fixed income markets, even though the former has more analytically attractive properties. See the discussion of KeyRateDuration in the FinanceModels.jl docs.
 """
 struct KeyRateZero{T, R} <: KeyRateDuration
     timepoint::T


### PR DESCRIPTION
## Summary

- Fix `KeyRateZero` docstring saying "Shift the **par** curve" → "Shift the **zero** curve" (copy-paste from `KeyRatePar`)
- Fix "the latter has more analytically attractive properties" → "the former" (`KeyRateZero` is the one with better properties, consistent with the `KeyRate` alias docstring)

## Test plan

- [ ] Docstring-only change — no behavioral impact
- [ ] Verify rendered docs show correct text

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)