### PR TITLE
AbstractDeflator ecosystem integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ActuaryUtilities"
 uuid = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 authors = ["Alec Loudenback"]
-version = "5.5.0"
+version = "5.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -19,8 +19,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Distributions = "0.25"
-FinanceCore = "^2"
-FinanceModels = "5.2"
+FinanceCore = "^2.6"
+FinanceModels = "^5.4"
 ForwardDiff = "^0.10"
 Optimization = "4.8.0, 5"
 OptimizationOptimJL = "0.4.5"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1083,3 +1083,53 @@ end
     kr_conv = sum(convexity(KeyRates(), zrc, cfs, times))
     @test vf_conv ≈ kr_conv atol = 1e-10
 end
+
+@testset "AbstractDeflator ecosystem integration" begin
+    # FinanceCore 2.6+ introduced AbstractDeflator. FinanceModels yield curves
+    # and MortalityTables mortality models both subtype it, so ActuaryUtilities's
+    # pv (re-exported from FinanceCore) works on composite deflators directly.
+
+    @testset "yield × default-survival composition" begin
+        yield = FM.Yield.Constant(FC.Continuous(0.03))
+        λ_d   = FC.Continuous(0.012)         # 1.2% default hazard
+        deflator = FC.compose(yield, λ_d)
+
+        @test deflator isa FC.AbstractDeflator
+
+        cfs = [FC.Cashflow(100.0, t) for t in 1.0:5.0]
+        expected = sum(100.0 * exp(-0.042 * t) for t in 1.0:5.0)
+        @test pv(deflator, cfs) ≈ expected
+    end
+
+    @testset "ELGD-adjusted defaultable bond price" begin
+        # Recovery-of-market-value: bake (1-R)·λ into the default process.
+        yield      = FM.Yield.Constant(FC.Continuous(0.03))
+        λ_marginal = FC.Continuous(0.012)
+        ELGD       = 0.60
+        λ_loss_adj = λ_marginal * ELGD
+
+        cfs = [FC.Cashflow(100.0, t) for t in 1.0:5.0]
+        no_recovery = pv(FC.compose(yield, λ_marginal), cfs)
+        with_recovery = pv(FC.compose(yield, λ_loss_adj), cfs)
+
+        # Recovery raises the present value (lower effective hazard)
+        @test with_recovery > no_recovery
+        # Numerical match to the ELGD * λ formula
+        @test with_recovery ≈ sum(100.0 * exp(-(0.03 + 0.0072) * t) for t in 1.0:5.0)
+    end
+
+    @testset "yield curve × constant decrement" begin
+        # Non-trivial term-structure yield composed with a mortality force
+        rates = [0.03, 0.035, 0.04, 0.045, 0.05]
+        mats  = [1.0, 2.0, 3.0, 5.0, 10.0]
+        yc = FM.fit(FM.Spline.Cubic(),
+                    FM.ZCBYield.(rates, mats),
+                    FM.Fit.Bootstrap())
+        μ = FC.Continuous(0.012)
+        deflator = FC.compose(yc, μ)
+
+        # PV of a 5-year cashflow contingent on survival
+        cf = FC.Cashflow(100.0, 5.0)
+        @test pv(deflator, [cf]) ≈ 100.0 * FC.factor(yc, 5) * exp(-0.012 * 5)
+    end
+end


### PR DESCRIPTION
## Summary

Bumps FinanceCore and FinanceModels compat to pick up the `AbstractDeflator` abstraction:
- FinanceCore `^2` → `^2.6` (introduces `AbstractDeflator`, `compose`, `factor`, `intensity` — see [FinanceCore #39](https://github.com/JuliaActuary/FinanceCore.jl/pull/39))
- FinanceModels `5.2` → `^5.4` (`AbstractYieldModel <: AbstractDeflator` — see [FinanceModels #255](https://github.com/JuliaActuary/FinanceModels.jl/pull/255))

ActuaryUtilities's `pv` (re-exported from FinanceCore) accepts composed deflators directly — the abstraction's `factor` plumbs through `discount`, which `pv(deflator, cashflows)` already uses. The existing yield-specific machinery (`duration`, `convexity`, `KeyRateDuration`, `sensitivities`, `IR01`/`CS01`/`DV01`) remains unchanged: those calculations are yield-curve-specific by mathematical convention, and no widening is required.

## Why ActuaryUtilities benefits without code changes

The headline workflow:
```julia
yield = FM.fit(FM.Spline.Cubic(), FM.CMTYield.(rates, mats), FM.Fit.Bootstrap())
λ_d   = Continuous(0.012)
ELGD  = 0.60
deflator = compose(yield, λ_d * ELGD)   # ELGD-adjusted defaultable deflator
pv(deflator, cashflows)                  # ActuaryUtilities.pv works directly
```

Bond pricing with credit risk and (eventually) mortality contingency now flows through one composition operator and one `pv` call, regardless of which deflator components are involved.

## Tests added

`test/runtests.jl` gains an `AbstractDeflator ecosystem integration` testset covering:
- `yield × default-survival` composition
- ELGD-adjusted defaultable bond pricing (Duffie-Singleton recovery-of-market-value)
- Term-structure yield × constant decrement composition

5 new tests, all passing alongside the existing 200+ tests.

## Coordination

Depends on:
- FinanceCore [#39](https://github.com/JuliaActuary/FinanceCore.jl/pull/39) → `2.6.0`
- FinanceModels [#255](https://github.com/JuliaActuary/FinanceModels.jl/pull/255) → `5.4.0`

Sister PR: MortalityTables [#134](https://github.com/JuliaActuary/MortalityTables.jl/pull/134).

Locally tested via `Pkg.develop` against the FinanceCore and FinanceModels branches.

## Test plan

- [x] All existing 200+ tests pass (no regressions)
- [x] 5 new ecosystem-integration tests pass
- [ ] Reviewer to verify CI passes once FinanceCore 2.6.0 and FinanceModels 5.4.0 are released

🤖 Generated with [Claude Code](https://claude.com/claude-code)