### PR TITLE
perf: use nested ForwardDiff.derivative for scalar convexity

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -434,9 +434,9 @@ function convexity(yield, cfs)
 end
 
 function convexity(yield, valuation_function::T) where {T <: Function}
-    v(x) = abs(valuation_function(yield + x[1]))
-    ∂²P = ForwardDiff.hessian(v, [0.0])
-    return ∂²P[1] / v([0.0])
+    v(x) = abs(valuation_function(yield + x))
+    ∂²P = ForwardDiff.derivative(y -> ForwardDiff.derivative(v, y), 0.0)
+    return ∂²P / v(0.0)
 end
 
 


### PR DESCRIPTION
## Summary

The 3-arg method `convexity(yield, valuation_function::Function)` was wrapping its scalar shock in a 1-element `Vector` (`[0.0]`, `x[1]`) so it could call `ForwardDiff.hessian`. For univariate inputs that's pure overhead — `hessian` sets up vector-AD machinery, walks a partials dimension, and allocates an output matrix, all to compute what nested `ForwardDiff.derivative` does with a single `Dual{Dual}` stacked at a scalar.

This is a strict swap of AD backend for the same mathematical result. No signature change, no semantics change, no downstream API impact. The other two `convexity` methods (`convexity(yield, cfs, times)` and `convexity(yield, cfs)`) call into this one and get the speedup for free.

```diff
 function convexity(yield, valuation_function::T) where {T <: Function}
-    v(x) = abs(valuation_function(yield + x[1]))
-    ∂²P = ForwardDiff.hessian(v, [0.0])
-    return ∂²P[1] / v([0.0])
+    v(x) = abs(valuation_function(yield + x))
+    ∂²P = ForwardDiff.derivative(y -> ForwardDiff.derivative(v, y), 0.0)
+    return ∂²P / v(0.0)
 end
```

## Benchmark

5-year, 4% semi-annual coupon bond at flat 3% continuous yield (`FinanceModels.Bond.Fixed`, 10 cashflows):

| version            |    min time | allocations |
|--------------------|------------:|------------:|
| before (hessian)   |      567 ns |          24 |
| after (derivative) |      266 ns |           8 |

~2.1× wall-clock, ~3× allocations.

## Test plan

- [x] `Pkg.test()` passes — all 72 tests in the `duration and convexity` testset green, plus everything else
- [x] Docstring example `convexity(0.03, my_lump_sum_value)` returns `28.27787727401264` (matches the documented `28.277877274012617` to machine precision, 14th-digit reorder)
- [x] `convexity(yield_ja, cfs_ja)` for a bond against `Yield.Constant{Continuous}` returns `26.820500017954323` identically to the prior implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)