### PR TITLE
Trigger CI on tag pushes and bump to 5.6.2 to publish /stable/

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [master]
+    tags: ['*']
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ActuaryUtilities"
 uuid = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 authors = ["Alec Loudenback"]
-version = "5.6.1"
+version = "5.6.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary

Follow-up to #135. The squash-merge of #135 picked up the docs fixes but not the workflow-tag-trigger commit, so v5.6.1 was tagged with the old workflow that doesn't fire on tag pushes. The docs job didn't run against v5.6.1, and `/stable/` is still stuck at v5.2.1.

This PR adds the missing `tags: ['*']` trigger and bumps to **5.6.2** so the next TagBot tag fires a tag-scoped docs build that publishes `/v5.6.2/` and advances the stable symlink.

After merge: comment `@JuliaRegistrator register` on the merge commit.

## Test plan

- [ ] PR CI passes
- [ ] After merge + TagBot tag, confirm `/v5.6.2/` appears on the docs site and `/stable/` resolves to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)