### PR TITLE
Fix invalid cross-page links on API page and bump to 5.6.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ActuaryUtilities"
 uuid = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 authors = ["Alec Loudenback"]
-version = "5.6.2"
+version = "5.6.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/API/ActuaryUtilities.md
+++ b/docs/src/API/ActuaryUtilities.md
@@ -1,6 +1,6 @@
 # ActuaryUtilities API Reference
 
-This page lists every documented symbol in `ActuaryUtilities` and its submodules. The full docstrings are rendered on the topic pages — [Financial Math](../../financial_math/), [Risk Measures](../../risk_measures/), and [Other Utilities](../../utilities/) — and each entry below links directly to its rendered docstring.
+This page lists every documented symbol in `ActuaryUtilities` and its submodules. The full docstrings are rendered on the topic pages — [Financial Math](../financial_math.md), [Risk Measures](../risk_measures.md), and [Other Utilities](../utilities.md) — and each entry below links directly to its rendered docstring.
 
 ```@index
 Modules = [


### PR DESCRIPTION
## Summary

The v5.6.2 tag docs build failed with:

> Error: invalid local link/image: path pointing to a file outside of build directory in docs/src/API/ActuaryUtilities.md

The intro paragraph added in #135 used built-URL relative paths (e.g. `../../financial_math/`) for cross-references to the topic pages. Documenter resolves source-relative `.md` paths during the cross-references pass, not built URLs, so it rejected them.

Switch the three links to source-relative `.md` paths:

```diff
-[Financial Math](../../financial_math/), [Risk Measures](../../risk_measures/), and [Other Utilities](../../utilities/)
+[Financial Math](../financial_math.md), [Risk Measures](../risk_measures.md), and [Other Utilities](../utilities.md)
```

Bump to **5.6.3** so the next TagBot tag fires the (now-tag-aware, post-#136) docs workflow and `/stable/` finally advances off v5.2.1.

After merge: comment `@JuliaRegistrator register` on the merge commit.

## Test plan

- [ ] PR CI passes (in particular the Documentation job)
- [ ] After merge + TagBot tag, confirm `/v5.6.3/` is published and `/stable/` resolves to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)