### PR TITLE
Allow FinanceModels 6 (compat: "5.5.1, 6")

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distributions = "0.25"
 FinanceCore = "^2"
-FinanceModels = "5.5.1"
+FinanceModels = "5.5.1, 6"
 ForwardDiff = "^0.10"
 Optimization = "4.8.0, 5"
 OptimizationOptimJL = "0.4.5"


### PR DESCRIPTION
Widens `[compat]` to allow **FinanceModels 6** alongside the existing `5.5.1+`:

```toml
FinanceModels = "5.5.1, 6"
```

### Why

FinanceModels 6.0 re-points `Spline.Linear/Quadratic/Cubic()` from global B-splines to **local, thread-safe interpolants**. The old B-spline-backed curves reused a single internal coefficient buffer that was overwritten on every evaluation, so evaluating one shared curve from multiple threads (e.g. concurrent `discount` in a multithreaded valuation) could silently return wrong values. The local interpolants are race-free (and faster).

### Downstream impact on ActuaryUtilities

The change is API-compatible. Verified against a dev'd FinanceModels 6.0:

- **Full AU test suite passes** — including `ZeroRateCurve sensitivities`, `ZeroRateCurve external validation` (AD vs finite-difference), `duration and convexity`, `IR01/CS01`, and the Hull-White paths.
- The **ForwardDiff key-rate-duration path** through `ZeroRateCurve(spline)` works for all spline types; Cubic KRDs match finite differences to 6 digits.
- Numerically: **Linear is identical**; Quadratic/Cubic shift slightly (effective durations move in the **4th–5th decimal** on a realistic curve — immaterial for risk metrics). `Spline.BSpline(2)`/`BSpline(3)` recover the prior numbers for anyone needing bit-reproducibility.

### Note

Takes effect once FinanceModels 6.0 is **registered** in the General registry (until then, resolution still selects 5.x and CI is unaffected). No AU version bump included here — can be added at release time if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
