### PR TITLE
Tier 1 cleanup: hygiene (const aliases, method-free duration decl, shared ratio kernel)

### DIFF
--- a/src/ActuaryUtilities.jl
+++ b/src/ActuaryUtilities.jl
@@ -11,8 +11,11 @@ import StatsBase
 using PrecompileTools
 import Distributions
 
-# need to define this here to extend it without conflict inside FinancialMath
-function duration() end
+# Declare the generic function here (with no methods) so both the FinancialMath
+# and Utilities submodules can add methods to the same `duration` without one
+# shadowing the other. `function duration end` adds no method; `duration()` with
+# parens would define a callable zero-arg method that silently returns `nothing`.
+function duration end
 
 include("financial_math.jl")
 include("risk_measures.jl")

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -259,7 +259,7 @@ A convenience constructor for [`KeyRateZero`](@ref).
 
 
 """
-KeyRate = KeyRateZero
+const KeyRate = KeyRateZero
 
 """
     duration(Macaulay(),interest_rate,cfs,times)
@@ -369,22 +369,10 @@ end
 # Macaulay here is the signed cashflow-weighted time Σ t·cf·d / Σ cf·d, which
 # matches the generic path's d/di log|V| for any sign of V.
 
-function _macaulay_ratio(yield, cfs, times)
-    # @inbounds below indexes `times` by `eachindex(cfs)` — a silent mismatch
-    # would read out of bounds rather than zip-truncate
-    length(cfs) == length(times) || throw(DimensionMismatch("cfs and times must have equal length"))
-    t1 = FinanceCore.timepoint(first(cfs), first(times))
-    z = _cf_value(first(cfs)) * FinanceCore.discount(yield, t1)
-    V = zero(z)
-    Vt = zero(z * t1)
-    @inbounds for k in eachindex(cfs)
-        t = FinanceCore.timepoint(cfs[k], times[k])
-        cfd = _cf_value(cfs[k]) * FinanceCore.discount(yield, t)
-        V += cfd
-        Vt += t * cfd
-    end
-    return Vt / V
-end
+# Macaulay (cashflow-weighted average time) is the identity-weighted ratio.
+# Shares the guarded `@inbounds` accumulation kernel `_weighted_ratio` (defined
+# alongside the convexity fast paths below) with the convexity statistics.
+_macaulay_ratio(yield, cfs, times) = _weighted_ratio(yield, identity, cfs, times)
 
 function duration(::Modified, yield::Real, cfs::AbstractVector, times)
     return _macaulay_ratio(yield, cfs, times) / (1 + yield)
@@ -562,14 +550,17 @@ end
 # The ratio uses the signed V, matching the generic path's |V|-normalized
 # second derivative for any sign of V (signs cancel).
 
-function _convexity_ratio(yield, weight, cfs, times)
+# Shared accumulation kernel: Σ weight(t)·cf·d / Σ cf·d. `weight = identity`
+# gives the Macaulay ratio (Modified-duration fast paths above); the t(t+1)/t²
+# weights below give the convexity statistics.
+function _weighted_ratio(yield, weight, cfs, times)
     # @inbounds below indexes `times` by `eachindex(cfs)` — a silent mismatch
     # would read out of bounds rather than zip-truncate
     length(cfs) == length(times) || throw(DimensionMismatch("cfs and times must have equal length"))
     t1 = FinanceCore.timepoint(first(cfs), first(times))
     z = _cf_value(first(cfs)) * FinanceCore.discount(yield, t1)
     V = zero(z)
-    Vw = zero(z * t1 * t1)
+    Vw = zero(weight(t1) * z)
     @inbounds for k in eachindex(cfs)
         t = FinanceCore.timepoint(cfs[k], times[k])
         cfd = _cf_value(cfs[k]) * FinanceCore.discount(yield, t)
@@ -580,17 +571,17 @@ function _convexity_ratio(yield, weight, cfs, times)
 end
 
 function convexity(yield::Real, cfs::AbstractVector, times)
-    return _convexity_ratio(yield, t -> t * (t + 1), cfs, times) / (1 + yield)^2
+    return _weighted_ratio(yield, t -> t * (t + 1), cfs, times) / (1 + yield)^2
 end
 function convexity(yield::FinanceCore.Rate{<:Real, FinanceCore.Periodic}, cfs::AbstractVector, times)
     m = yield.compounding.frequency
-    return _convexity_ratio(yield, t -> t * (t + 1 / m), cfs, times) / (1 + FinanceCore.rate(yield) / m)^2
+    return _weighted_ratio(yield, t -> t * (t + 1 / m), cfs, times) / (1 + FinanceCore.rate(yield) / m)^2
 end
 function convexity(yield::FinanceCore.Rate{<:Real, FinanceCore.Continuous}, cfs::AbstractVector, times)
-    return _convexity_ratio(yield, t -> t * t, cfs, times)
+    return _weighted_ratio(yield, t -> t * t, cfs, times)
 end
 function convexity(yield::FinanceModels.Yield.Constant{<:FinanceCore.Rate}, cfs::AbstractVector, times)
-    return _convexity_ratio(yield.rate, t -> t * (t + 1), cfs, times)
+    return _weighted_ratio(yield.rate, t -> t * (t + 1), cfs, times)
 end
 # disambiguation vs `convexity(curve::AYM, tenors, cfs::AbstractVector{<:Cashflow})`:
 # a Cashflow vector in the third position means (tenors, cashflows), not (cfs, times)

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -78,7 +78,7 @@ g(rm::VaR, x) = x < (1 - rm.α) ? 0 : 1
 """
 [`VaR`](@ref)
 """
-ValueAtRisk = VaR
+const ValueAtRisk = VaR
 
 """
     CTE(α)::RiskMeasure
@@ -119,7 +119,7 @@ g(rm::CTE, x) = x < (1 - rm.α) ? x / (1 - rm.α) : 1
 """
 [`CTE`](@ref)
 """
-ConditionalTailExpectation = CTE
+const ConditionalTailExpectation = CTE
 
 """
     WangTransform(α)::RiskMeasure


### PR DESCRIPTION
**Tier 1 of a 3-PR cleanup stack** from a maintainability audit of `financial_math.jl`. This PR is the "quick, safe wins" tier — no behavioral change. Tiers 2 (consolidation) and 3 (architectural) stack on top of this branch.

### Changes

1. **`const` three exported aliases** — `KeyRate` (`financial_math.jl`), `ValueAtRisk` and `ConditionalTailExpectation` (`risk_measures.jl`). All three were plain (non-`const`) exported globals, which force a dynamic lookup at every use site and are a type-stability trap.

2. **Declare `duration` method-free** — `function duration end` instead of `function duration() end` in `ActuaryUtilities.jl`. The parenthesized form defined a callable zero-arg method that silently returned `nothing` (verified) instead of raising a `MethodError`. The intent was only to declare the generic function so both submodules can extend it.

3. **Share the accumulation kernel** — `_macaulay_ratio` duplicated the guarded `@inbounds` loop of `_convexity_ratio` byte-for-byte except for the per-term weight. Renamed `_convexity_ratio` → `_weighted_ratio` (generalized accumulator init) and defined `_macaulay_ratio(y,c,t) = _weighted_ratio(y, identity, c, t)`. Verified bit-equal before the change.

### Testing

Full `Pkg.test` suite + Aqua pass, with every sub-suite matching the pre-change baseline counts exactly (AD-vs-analytic byte-equivalence 19/19, duration/convexity 72/72, Aqua 11/11). Net −6 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)