### PR TITLE
Tier 3 cleanup: one key-rate hat implementation; drop dead valuation helpers

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -672,45 +672,16 @@ function _tent_bump(shift, τ, krd_points)
             "KeyRateDuration timepoint $τ is not a point of the krd_points grid $krd_points; pass krd_points containing the shifted timepoint"
         )
     )
-    n = length(krd_points)
-
-    τ_left = idx > 1 ? krd_points[idx-1] : nothing
-    τ_right = idx < n ? krd_points[idx+1] : nothing
-
-    return function (z, t)
-        if τ_left === nothing && τ_right === nothing
-            # Single KRD point: flat shift everywhere
-            bump = shift
-        elseif τ_left === nothing
-            # First point: flat left, ramp right
-            if t <= τ
-                bump = shift
-            elseif t >= τ_right
-                bump = oftype(shift, 0)
-            else
-                bump = shift * (τ_right - t) / (τ_right - τ)
-            end
-        elseif τ_right === nothing
-            # Last point: ramp left, flat right
-            if t >= τ
-                bump = shift
-            elseif t <= τ_left
-                bump = oftype(shift, 0)
-            else
-                bump = shift * (t - τ_left) / (τ - τ_left)
-            end
-        else
-            # Interior: triangle peak at τ
-            if t <= τ_left || t >= τ_right
-                bump = oftype(shift, 0)
-            elseif t <= τ
-                bump = shift * (t - τ_left) / (τ - τ_left)
-            else
-                bump = shift * (τ_right - t) / (τ_right - τ)
-            end
-        end
-        return z + FinanceCore.Continuous(bump)
-    end
+    # A single-knot tent is the modern `_hat_bump` kernel (defined alongside the
+    # AD KRD path below) evaluated at a unit bump vector for this knot — one
+    # source of truth for the key-rate hat shape across the legacy
+    # bump-and-reprice path and the AD path. The flat extrapolation `_hat_bump`
+    # applies beyond the first / last knot reproduces the original first-point
+    # (flat left) and last-point (flat right) tent behavior. Numerically
+    # identical to the prior explicit tent (max abs deviation ~7e-18 over a knot
+    # / t sweep, from float associativity in the ramp).
+    bumps = [k == idx ? shift : zero(shift) for k in eachindex(krd_points)]
+    return (z, t) -> z + FinanceCore.Continuous(_hat_bump(krd_points, bumps, t))
 end
 
 _ensure_yield_model(curve::FinanceModels.Yield.AbstractYieldModel) = curve
@@ -918,12 +889,6 @@ function _keyrate_ad(base::AYM, credit::AYM, tenors::AbstractVector, valuation_f
     end
     return (; value = v, base_gradient = base_grad, credit_gradient = credit_grad)
 end
-
-# Standard valuation for fixed cashflows
-_valuation(cfs, times) = curve -> sum(cf * curve(t) for (cf, t) in zip(cfs, times))
-
-# Two-curve standard valuation (additive on rates → multiplicative on discount factors)
-_valuation2(cfs, times) = (base, credit) -> sum(cf * base(t) * credit(t) for (cf, t) in zip(cfs, times))
 
 # ─── Closed-form KRD for the vanilla cashflow case ──────────────────────
 #


### PR DESCRIPTION
**Tier 3 (final) of the 3-PR cleanup stack.** Stacked on **#146** (Tier 2), which is stacked on **#145** (Tier 1) — merge in order; this diff is against the Tier 2 branch.

Architectural consolidation, no behavioral change. −35 net lines (`financial_math.jl` 1682 → 1647; **1775 on master before the stack, −128 total**).

### 1. One triangular key-rate hat, not two

The package had two independent implementations of the same triangular key-rate "hat":

- `_tent_bump` — legacy `KeyRateDuration` (par/zero) bump-and-reprice path, a ~45-line explicit first/interior/last-point tent.
- `_hat_bump` — modern AD `KeyRates` path.

A single-knot tent is exactly `_hat_bump` evaluated at a unit bump vector for that knot, including the flat extrapolation beyond the first/last knot. `_tent_bump` now delegates to `_hat_bump`, so there's a single source of truth for the hat shape. Verified numerically identical before committing:

```
max abs deviation = 6.9e-18   # over a 200-pt t-sweep at every knot of 4 grids
```

That's float-associativity noise in the ramp (`(1-w)·shift` vs `shift·(τ_right−t)/(τ_right−τ)`), ~14 orders below the legacy tests' tolerances. The `τ ∉ grid` `ArgumentError` is preserved.

### 2. Remove dead `_valuation` / `_valuation2`

Orphaned since the contract-unification work (#141) replaced them with `_cvalue` / `_cvalue2`. Zero call sites in `src` or `test`.

### Testing

Full `Pkg.test` + Aqua pass. Path-specific guards: **legacy KeyRateDuration conveniences 3/3**, the `_tent_bump` exact-bump-value tests (inside "duration and convexity" 72/72), AD-vs-analytic byte-equivalence 19/19, Aqua 11/11.

### Deliberately deferred (need your design call)

These audit items are larger / taste-driven and are left for you to direct rather than impose in this stack:

- **Split `financial_math.jl` into focused files** (scalar duration / key-rate / contracts / short-rate). Purely organizational and behavior-preserving, but the file boundaries are an opinion better owned by the maintainer.
- **A single internal `sensitivities`-style core** that all public `duration`/`convexity`/`dv01` curve forms slice from (the contract forms already do this; the curve forms still re-enter the helpers independently).
- **Retiring the legacy `KeyRateDuration` (par/zero) system** in favor of `KeyRates` once `KeyRatePar` has an AD-based equivalent. (This PR removes the *duplicated hat math* but keeps both public APIs.)
- **Forwarder boilerplate** (the ~19 `Cashflow`-vector + ~15 do-block one-liners): a method-generating macro would shrink them but hurts grep/IDE discoverability — I judged explicit methods the better default for a library.
- **Per-function docstring examples**: deliberately *not* de-duplicated — standalone `?convexity` / `?duration` examples are worth the small redundancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)