### PR TITLE
Fix Wasserstein and distortion-risk correctness

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -952,6 +952,9 @@ end
 # role positions.
 function _ncurve_analytic(curves::NamedTuple, tenors::AbstractVector,
                               cfs::AbstractVector, times; order = 1)
+    length(times) >= length(cfs) || throw(
+        DimensionMismatch("times must contain at least one entry for each cashflow")
+    )
     L = length(curves)
     n = length(tenors)
     T = float(promote_type(eltype(cfs), eltype(times)))

--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -952,7 +952,7 @@ end
 # role positions.
 function _ncurve_analytic(curves::NamedTuple, tenors::AbstractVector,
                               cfs::AbstractVector, times; order = 1)
-    length(times) >= length(cfs) || throw(
+    checkbounds(Bool, times, eachindex(cfs)) || throw(
         DimensionMismatch("times must contain at least one entry for each cashflow")
     )
     L = length(curves)

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -78,7 +78,10 @@ evaluation budget scales with the number of empirical quantile segments; an
 explicit `maxevals` is a hard cap. If the requested tolerance cannot be verified,
 `wasserstein` throws rather than returning an unconverged approximation.
 For distributional `p=Inf`, this includes empirical-versus-bounded-distribution
-cases whose supremum is not certified within the evaluation budget.
+cases whose supremum is not certified within the evaluation budget. Infinite
+distance is returned only when proved by support bounds or a supported analytic
+family; unresolved same-side-unbounded pairs throw rather than relying on tail
+growth heuristics.
 
 ## References
 - "Optimal Transport for Actuarial Science", Arthur Charpentier, 2026.
@@ -173,18 +176,24 @@ function _wasserstein_infinity(a::Distributions.Normal, b::Distributions.Normal;
     a.σ == b.σ ? abs(a.μ - b.μ) : Inf
 end
 
+function _wasserstein_infinity(a::Distributions.LogNormal, b::Distributions.LogNormal; kwargs...)
+    Distributions.params(a) == Distributions.params(b) ? 0.0 : Inf
+end
+
+function _wasserstein_infinity(a::Distributions.Cauchy, b::Distributions.Cauchy; kwargs...)
+    a.σ == b.σ ? abs(a.μ - b.μ) : Inf
+end
+
 function _wasserstein_infinity(a, b; rtol, atol, maxevals)
     _support_proves_infinite(a, b) && return Inf
     alo, ahi = _support_bounds(a)
     blo, bhi = _support_bounds(b)
-    bounded_supports = all(isfinite, (alo, ahi, blo, bhi))
     endpoint_gap = zero(float(promote_type(typeof(alo), typeof(ahi), typeof(blo), typeof(bhi))))
     isfinite(alo) && isfinite(blo) && (endpoint_gap = max(endpoint_gap, abs(alo - blo)))
     isfinite(ahi) && isfinite(bhi) && (endpoint_gap = max(endpoint_gap, abs(ahi - bhi)))
     Qa, Qb = _quantile_fn(a), _quantile_fn(b)
     previous = -Inf
     stable = 0
-    growing = 0
     evaluations = 0
     n = 64
     budget = isnothing(maxevals) ? 100_000 : maxevals
@@ -202,12 +211,6 @@ function _wasserstein_infinity(a, b; rtol, atol, maxevals)
             stable >= 3 && return current
         else
             stable = 0
-        end
-        if isfinite(previous) && current - previous > tolerance
-            growing += 1
-            growing >= 8 && !bounded_supports && return Inf
-        else
-            growing = 0
         end
         previous = current
         n *= 2

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -4,6 +4,7 @@ import ..Distributions
 import ..StatsBase
 import ..RiskMeasures
 import ..RiskMeasures: RiskMeasure, CTE, VaR
+import ..QuadGK
 import Random
 import Statistics
 
@@ -30,10 +31,11 @@ function _quantile_fn(x::AbstractVector{<:Real})
     return u -> xs[clamp(ceil(Int, u * n), 1, n)]
 end
 
-_pnorm(diffs, p) = (Statistics.mean(abs.(diffs) .^ p))^(1 / p)
+_pnorm(diffs, p) = isinf(p) ? maximum(abs, diffs) :
+    (Statistics.mean(abs.(diffs) .^ p))^(1 / p)
 
 """
-    wasserstein(a, b; p=1)
+    wasserstein(a, b; p=1, rtol=sqrt(eps()), atol=0, maxevals=100_000)
 
 The `p`-Wasserstein (optimal transport) distance between two one-dimensional
 risks. Each of `a`, `b` may be a sample (`AbstractVector{<:Real}`) or a
@@ -70,13 +72,23 @@ julia> wasserstein(Normal(0, 1), Normal(0, 2); p=2) # same mean, |σ₁-σ₂|
 
 See also [`transportmap`](@ref), [`driftsignificance`](@ref), [`robustvalue`](@ref).
 
+For risks involving a distribution, the quantile integral is evaluated adaptively.
+`rtol`, `atol`, and `maxevals` control that calculation. If the requested
+tolerance cannot be verified, `wasserstein` throws rather than returning an
+unconverged approximation.
+
 ## References
 - "Optimal Transport for Actuarial Science", Arthur Charpentier, 2026.
   [⟨hal-05684645⟩](https://hal.science/hal-05684645)
 """
-function wasserstein(a, b; p::Real=1)
-    p >= 1 || throw(ArgumentError("p must be ≥ 1, got $p"))
-    _wasserstein(a, b, p)
+function wasserstein(a, b; p::Real=1, rtol::Real=sqrt(eps()),
+                     atol::Real=0, maxevals::Integer=100_000)
+    (p >= 1 && (isfinite(p) || p == Inf)) ||
+        throw(ArgumentError("p must be finite and ≥ 1, or Inf; got $p"))
+    (isfinite(rtol) && rtol >= 0) || throw(ArgumentError("rtol must be finite and nonnegative"))
+    (isfinite(atol) && atol >= 0) || throw(ArgumentError("atol must be finite and nonnegative"))
+    maxevals > 0 || throw(ArgumentError("maxevals must be positive"))
+    _wasserstein(a, b, p; rtol, atol, maxevals)
 end
 
 # both samples: exact in both cases. Equal sizes reduce to sorted point-by-point
@@ -85,7 +97,7 @@ end
 # (or an interpolated quantile) computes a different number — e.g. the true
 # W₂([0], [0,2]) is √2, while a size-2 midpoint grid through `Statistics.quantile`
 # gives √1.25.
-function _wasserstein(a::AbstractVector{<:Real}, b::AbstractVector{<:Real}, p)
+function _wasserstein(a::AbstractVector{<:Real}, b::AbstractVector{<:Real}, p; kwargs...)
     (isempty(a) || isempty(b)) &&
         throw(ArgumentError("empty sample: wasserstein needs at least one observation in each of `a`, `b`"))
     na, nb = length(a), length(b)
@@ -96,20 +108,92 @@ function _wasserstein(a::AbstractVector{<:Real}, b::AbstractVector{<:Real}, p)
     acc = 0.0
     while i <= na && j <= nb
         u = min(i / na, j / nb)
-        acc += (u - prev) * abs(as[i] - bs[j])^p
+        gap = abs(as[i] - bs[j])
+        acc = isinf(p) ? max(acc, gap) : acc + (u - prev) * gap^p
         prev = u
         i / na <= u && (i += 1)
         j / nb <= u && (j += 1)
     end
-    return acc^(1 / p)
+    return isinf(p) ? acc : acc^(1 / p)
 end
 
-# at least one argument is a distribution: integrate the quantile gap on a grid
-function _wasserstein(a, b, p)
-    n = 4096
-    us = ((1:n) .- 0.5) ./ n
+# A divergent endpoint integral has tail-shell masses that do not tend to zero.
+# This deliberately conservative detector only reports divergence when the last
+# five dyadic shells are essentially flat; ambiguous non-convergence remains an
+# error rather than being converted to a finite number or to Inf.
+function _divergent_quantile_tail(f)
+    shells = map(12:20) do k
+        ε = exp2(-k)
+        width = ε / 2
+        width * (f(3ε / 4) + f(1 - 3ε / 4))
+    end
+    tail = @view shells[end-4:end]
+    return all(isfinite, tail) && minimum(tail) > 0 && minimum(tail) / maximum(tail) > 0.98
+end
+
+_quantile_breaks(::Distributions.UnivariateDistribution) = Float64[]
+_quantile_breaks(x::AbstractVector) = collect((1:(length(x) - 1)) ./ length(x))
+
+function _wasserstein_finite(a, b, p; rtol, atol, maxevals)
     Qa, Qb = _quantile_fn(a), _quantile_fn(b)
-    _pnorm([Qa(u) - Qb(u) for u in us], p)
+    f(u) = abs(Qa(u) - Qb(u))^p
+    # Empirical quantiles jump at i/n. Supplying those known discontinuities as
+    # interval boundaries lets QuadGK spend its error budget on the continuous
+    # distribution quantile rather than repeatedly rediscovering every rank.
+    points = sort!(unique!([0.0; 0.5; _quantile_breaks(a); _quantile_breaks(b); 1.0]))
+    integral, err = QuadGK.quadgk(f, points...; rtol, atol, maxevals)
+    tolerance = max(atol, rtol * abs(integral))
+    if !isfinite(integral)
+        return Inf
+    elseif err <= tolerance
+        return integral^(1 / p)
+    elseif _divergent_quantile_tail(f)
+        return Inf
+    end
+    throw(ErrorException("wasserstein quantile integration did not converge: estimated error $err exceeds tolerance $tolerance"))
+end
+
+# Distributional W∞ is the supremum quantile gap. Successively refined midpoint
+# grids give monotone lower bounds; a finite answer is returned only after several
+# refinements agree. Persistent growth is reported as Inf only when clearly
+# unbounded, otherwise exhaustion is a loud convergence error.
+function _wasserstein_infinity(a, b; rtol, atol, maxevals)
+    Qa, Qb = _quantile_fn(a), _quantile_fn(b)
+    previous = -Inf
+    stable = 0
+    growing = 0
+    evaluations = 0
+    n = 64
+    while evaluations + n <= maxevals
+        current = maximum(1:n) do k
+            u = (k - 0.5) / n
+            abs(Qa(u) - Qb(u))
+        end
+        evaluations += n
+        !isfinite(current) && return Inf
+        tolerance = max(atol, rtol * abs(current))
+        if current - previous <= tolerance
+            stable += 1
+            stable >= 3 && return current
+        else
+            stable = 0
+        end
+        if isfinite(previous) && previous > 0 && current / previous > 1.25
+            growing += 1
+            growing >= 4 && return Inf
+        else
+            growing = 0
+        end
+        previous = current
+        n *= 2
+    end
+    throw(ErrorException("wasserstein W∞ supremum search did not converge within maxevals=$maxevals"))
+end
+
+# At least one argument is a distribution: use verified adaptive computation.
+function _wasserstein(a, b, p; rtol, atol, maxevals)
+    isinf(p) ? _wasserstein_infinity(a, b; rtol, atol, maxevals) :
+        _wasserstein_finite(a, b, p; rtol, atol, maxevals)
 end
 
 """

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -35,7 +35,7 @@ _pnorm(diffs, p) = isinf(p) ? maximum(abs, diffs) :
     (Statistics.mean(abs.(diffs) .^ p))^(1 / p)
 
 """
-    wasserstein(a, b; p=1, rtol=sqrt(eps()), atol=0, maxevals=100_000)
+    wasserstein(a, b; p=1, rtol=1e-6, atol=0, maxevals=nothing)
 
 The `p`-Wasserstein (optimal transport) distance between two one-dimensional
 risks. Each of `a`, `b` may be a sample (`AbstractVector{<:Real}`) or a
@@ -73,21 +73,22 @@ julia> wasserstein(Normal(0, 1), Normal(0, 2); p=2) # same mean, |σ₁-σ₂|
 See also [`transportmap`](@ref), [`driftsignificance`](@ref), [`robustvalue`](@ref).
 
 For risks involving a distribution, the quantile integral is evaluated adaptively.
-`rtol`, `atol`, and `maxevals` control that calculation. If the requested
-tolerance cannot be verified, `wasserstein` throws rather than returning an
-unconverged approximation.
+`rtol`, `atol`, and `maxevals` control that calculation. By default the
+evaluation budget scales with the number of empirical quantile segments; an
+explicit `maxevals` is a hard cap. If the requested tolerance cannot be verified,
+`wasserstein` throws rather than returning an unconverged approximation.
 
 ## References
 - "Optimal Transport for Actuarial Science", Arthur Charpentier, 2026.
   [⟨hal-05684645⟩](https://hal.science/hal-05684645)
 """
-function wasserstein(a, b; p::Real=1, rtol::Real=sqrt(eps()),
-                     atol::Real=0, maxevals::Integer=100_000)
+function wasserstein(a, b; p::Real=1, rtol::Real=1.0e-6,
+                     atol::Real=0, maxevals::Union{Nothing,Integer}=nothing)
     (p >= 1 && (isfinite(p) || p == Inf)) ||
         throw(ArgumentError("p must be finite and ≥ 1, or Inf; got $p"))
     (isfinite(rtol) && rtol >= 0) || throw(ArgumentError("rtol must be finite and nonnegative"))
     (isfinite(atol) && atol >= 0) || throw(ArgumentError("atol must be finite and nonnegative"))
-    maxevals > 0 || throw(ArgumentError("maxevals must be positive"))
+    (isnothing(maxevals) || maxevals > 0) || throw(ArgumentError("maxevals must be positive"))
     _wasserstein(a, b, p; rtol, atol, maxevals)
 end
 
@@ -122,7 +123,7 @@ end
 # five dyadic shells are essentially flat; ambiguous non-convergence remains an
 # error rather than being converted to a finite number or to Inf.
 function _divergent_quantile_tail(f)
-    shells = map(12:20) do k
+    shells = map(20:30) do k
         ε = exp2(-k)
         width = ε / 2
         width * (f(3ε / 4) + f(1 - 3ε / 4))
@@ -141,7 +142,8 @@ function _wasserstein_finite(a, b, p; rtol, atol, maxevals)
     # interval boundaries lets QuadGK spend its error budget on the continuous
     # distribution quantile rather than repeatedly rediscovering every rank.
     points = sort!(unique!([0.0; 0.5; _quantile_breaks(a); _quantile_breaks(b); 1.0]))
-    integral, err = QuadGK.quadgk(f, points...; rtol, atol, maxevals)
+    budget = isnothing(maxevals) ? max(100_000, 30 * (length(points) - 1)) : maxevals
+    integral, err = QuadGK.quadgk(f, points; rtol, atol, maxevals=budget)
     tolerance = max(atol, rtol * abs(integral))
     if !isfinite(integral)
         return Inf
@@ -153,23 +155,37 @@ function _wasserstein_finite(a, b, p; rtol, atol, maxevals)
     throw(ErrorException("wasserstein quantile integration did not converge: estimated error $err exceeds tolerance $tolerance"))
 end
 
-# Distributional W∞ is the supremum quantile gap. Successively refined midpoint
-# grids give monotone lower bounds; a finite answer is returned only after several
-# refinements agree. Persistent growth is reported as Inf only when clearly
-# unbounded, otherwise exhaustion is a loud convergence error.
+# Distributional W∞ is the supremum quantile gap. The k/n grids are nested under
+# doubling, so their maxima are monotone lower bounds. A finite answer is returned
+# only after several refinements agree; unresolved tails fail loudly.
+_support_bounds(d::Distributions.UnivariateDistribution) = (minimum(d), maximum(d))
+_support_bounds(x::AbstractVector) = extrema(x)
+
+function _support_proves_infinite(a, b)
+    alo, ahi = _support_bounds(a)
+    blo, bhi = _support_bounds(b)
+    return xor(isfinite(alo), isfinite(blo)) || xor(isfinite(ahi), isfinite(bhi))
+end
+
+function _wasserstein_infinity(a::Distributions.Normal, b::Distributions.Normal; kwargs...)
+    a.σ == b.σ ? abs(a.μ - b.μ) : Inf
+end
+
 function _wasserstein_infinity(a, b; rtol, atol, maxevals)
+    _support_proves_infinite(a, b) && return Inf
     Qa, Qb = _quantile_fn(a), _quantile_fn(b)
     previous = -Inf
     stable = 0
     growing = 0
     evaluations = 0
     n = 64
-    while evaluations + n <= maxevals
-        current = maximum(1:n) do k
-            u = (k - 0.5) / n
+    budget = isnothing(maxevals) ? 100_000 : maxevals
+    while evaluations + n - 1 <= budget
+        current = maximum(1:(n - 1)) do k
+            u = k / n
             abs(Qa(u) - Qb(u))
         end
-        evaluations += n
+        evaluations += n - 1
         !isfinite(current) && return Inf
         tolerance = max(atol, rtol * abs(current))
         if current - previous <= tolerance
@@ -178,16 +194,16 @@ function _wasserstein_infinity(a, b; rtol, atol, maxevals)
         else
             stable = 0
         end
-        if isfinite(previous) && previous > 0 && current / previous > 1.25
+        if isfinite(previous) && current - previous > tolerance
             growing += 1
-            growing >= 4 && return Inf
+            growing >= 8 && return Inf
         else
             growing = 0
         end
         previous = current
         n *= 2
     end
-    throw(ErrorException("wasserstein W∞ supremum search did not converge within maxevals=$maxevals"))
+    throw(ErrorException("wasserstein W∞ supremum search did not converge within maxevals=$budget"))
 end
 
 # At least one argument is a distribution: use verified adaptive computation.
@@ -348,6 +364,10 @@ loss. What is returned depends on the measure:
   `radius` in ``W_p``. This is a **lower bound** on the true worst case over the
   ball, not the supremum itself — treat it as a principled adverse scenario, not
   a proven maximum.
+
+Because the exact CTE branch applies only when `tail == rm.α`, changing `tail`
+across that equality switches between the atom-splitting exact bound and the
+whole-atom adverse scenario; the returned value need not be continuous there.
 
 The factor `(1 - tail)^(-1/p)` is the price of tail focus: deeper-tail capital is
 intrinsically more fragile to model error, so the same `radius` buys a larger

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -77,6 +77,8 @@ For risks involving a distribution, the quantile integral is evaluated adaptivel
 evaluation budget scales with the number of empirical quantile segments; an
 explicit `maxevals` is a hard cap. If the requested tolerance cannot be verified,
 `wasserstein` throws rather than returning an unconverged approximation.
+For distributional `p=Inf`, this includes empirical-versus-bounded-distribution
+cases whose supremum is not certified within the evaluation budget.
 
 ## References
 - "Optimal Transport for Actuarial Science", Arthur Charpentier, 2026.
@@ -173,6 +175,12 @@ end
 
 function _wasserstein_infinity(a, b; rtol, atol, maxevals)
     _support_proves_infinite(a, b) && return Inf
+    alo, ahi = _support_bounds(a)
+    blo, bhi = _support_bounds(b)
+    bounded_supports = all(isfinite, (alo, ahi, blo, bhi))
+    endpoint_gap = zero(float(promote_type(typeof(alo), typeof(ahi), typeof(blo), typeof(bhi))))
+    isfinite(alo) && isfinite(blo) && (endpoint_gap = max(endpoint_gap, abs(alo - blo)))
+    isfinite(ahi) && isfinite(bhi) && (endpoint_gap = max(endpoint_gap, abs(ahi - bhi)))
     Qa, Qb = _quantile_fn(a), _quantile_fn(b)
     previous = -Inf
     stable = 0
@@ -181,10 +189,11 @@ function _wasserstein_infinity(a, b; rtol, atol, maxevals)
     n = 64
     budget = isnothing(maxevals) ? 100_000 : maxevals
     while evaluations + n - 1 <= budget
-        current = maximum(1:(n - 1)) do k
+        interior = maximum(1:(n - 1)) do k
             u = k / n
             abs(Qa(u) - Qb(u))
         end
+        current = max(endpoint_gap, interior)
         evaluations += n - 1
         !isfinite(current) && return Inf
         tolerance = max(atol, rtol * abs(current))
@@ -196,7 +205,7 @@ function _wasserstein_infinity(a, b; rtol, atol, maxevals)
         end
         if isfinite(previous) && current - previous > tolerance
             growing += 1
-            growing >= 8 && return Inf
+            growing >= 8 && !bounded_supports && return Inf
         else
             growing = 0
         end

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -174,6 +174,10 @@ DualPower(v) returns a functor which can then be called on a risk distribution.
 """
 struct DualPower{T} <: RiskMeasure
     v::T
+    function DualPower(v::T) where {T}
+        (isfinite(v) && v > 0) || throw(ArgumentError("v must be finite and strictly positive, got $v"))
+        return new{T}(v)
+    end
 end
 g(rm::DualPower, x) = 1 - (1 - x)^rm.v
 
@@ -199,6 +203,10 @@ julia> rm(rand(1000))
 """
 struct ProportionalHazard{T} <: RiskMeasure
     y::T
+    function ProportionalHazard(y::T) where {T}
+        (isfinite(y) && y > 0) || throw(ArgumentError("y must be finite and strictly positive, got $y"))
+        return new{T}(y)
+    end
 end
 g(rm::ProportionalHazard, x) = x^(1 / rm.y)
 

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -179,6 +179,7 @@ struct DualPower{T} <: RiskMeasure
         return new{T}(v)
     end
 end
+DualPower{T}(v) where {T} = DualPower(convert(T, v))
 g(rm::DualPower, x) = 1 - (1 - x)^rm.v
 
 """
@@ -208,6 +209,7 @@ struct ProportionalHazard{T} <: RiskMeasure
         return new{T}(y)
     end
 end
+ProportionalHazard{T}(y) where {T} = ProportionalHazard(convert(T, y))
 g(rm::ProportionalHazard, x) = x^(1 / rm.y)
 
 function (rm::RiskMeasure)(risk)

--- a/test/audit.jl
+++ b/test/audit.jl
@@ -189,6 +189,12 @@ end
     # a silent mismatch must not read out of bounds (or zip-truncate)
     @test_throws DimensionMismatch duration(0.03, [1.0, 2.0, 3.0], [1.0, 2.0])
     @test_throws DimensionMismatch convexity(0.03, [1.0, 2.0, 3.0], 1:2)
+    curve = FM.Yield.Constant(0.03)
+    kr = KeyRates([1.0, 2.0, 3.0])
+    @test_throws DimensionMismatch sensitivities(kr, curve, [1.0, 2.0, 3.0], [1.0, 2.0])
+    # Extra time positions represent zero cashflows and are intentionally harmless.
+    @test sensitivities(kr, curve, [1.0, 2.0], [1.0, 2.0, 3.0]) ==
+          sensitivities(kr, curve, [1.0, 2.0], [1.0, 2.0])
 end
 
 @testset "locked_floater requires whole coupon periods on the forward leg" begin

--- a/test/optimal_transport.jl
+++ b/test/optimal_transport.jl
@@ -41,7 +41,15 @@
         @test wasserstein(Cauchy(), Dirac(0.0); p=1) == Inf
         @test wasserstein(Cauchy(), Cauchy(3, 1); p=1) ≈ 3.0
         @test wasserstein(Normal(), Normal(3, 1); p=Inf) ≈ 3.0
-        @test_throws ErrorException wasserstein(Normal(), Normal(3, 1); p=Inf, maxevals=64)
+        @test wasserstein(Normal(), Normal(0, 2); p=Inf) == Inf
+        @test wasserstein(randn(MersenneTwister(11), 100), Normal(); p=Inf) == Inf
+        # The empirical law is bounded, so its W₁ distance from a true Cauchy
+        # law is infinite even when the observations themselves came from Cauchy.
+        @test wasserstein(rand(MersenneTwister(12), Cauchy(), 5_000), Cauchy()) == Inf
+        # Scenario counts used in practice must not exhaust the default budget on
+        # the initial quadrature pass merely because every empirical rank is a break.
+        @test isfinite(wasserstein(randn(MersenneTwister(13), 10_000), Normal()))
+        @test_throws ErrorException wasserstein(Uniform(0, 1), Uniform(3, 4); p=Inf, maxevals=64)
     end
 
     @testset "transportmap / pushforward" begin

--- a/test/optimal_transport.jl
+++ b/test/optimal_transport.jl
@@ -42,6 +42,10 @@
         @test wasserstein(Cauchy(), Cauchy(3, 1); p=1) ≈ 3.0
         @test wasserstein(Normal(), Normal(3, 1); p=Inf) ≈ 3.0
         @test wasserstein(Normal(), Normal(0, 2); p=Inf) == Inf
+        @test wasserstein(LogNormal(0, 1), LogNormal(0, 1); p=Inf) == 0.0
+        @test wasserstein(LogNormal(0, 1), LogNormal(0, 2); p=Inf) == Inf
+        @test wasserstein(Cauchy(), Cauchy(3, 1); p=Inf) ≈ 3.0
+        @test wasserstein(Cauchy(), Cauchy(0, 2); p=Inf) == Inf
         @test wasserstein(Uniform(0, 1), Uniform(0, 2); p=Inf) ≈ 1.0
         @test wasserstein(Uniform(-2, 1), Uniform(0, 2); p=Inf) ≈ 2.0
         @test wasserstein(randn(MersenneTwister(11), 100), Normal(); p=Inf) == Inf
@@ -52,6 +56,8 @@
         # the initial quadrature pass merely because every empirical rank is a break.
         @test isfinite(wasserstein(randn(MersenneTwister(13), 10_000), Normal()))
         @test_throws ErrorException wasserstein(Uniform(0, 1), Uniform(3, 4); p=Inf, maxevals=64)
+        mix = MixtureModel([Normal(0, 1), Normal(5, 1)], [0.99, 0.01])
+        @test_throws ErrorException wasserstein(mix, Normal(); p=Inf)
     end
 
     @testset "transportmap / pushforward" begin

--- a/test/optimal_transport.jl
+++ b/test/optimal_transport.jl
@@ -23,6 +23,9 @@
         # quantiles would give √1.25) and W₁ = 1.
         @test wasserstein([0], [0, 2]; p=2) ≈ sqrt(2)
         @test wasserstein([0], [0, 2]; p=1) ≈ 1.0
+        @test wasserstein([0], [0, 2]; p=Inf) ≈ 2.0
+        @test wasserstein([0.0, 10.0], [0.0, 0.0]; p=Inf) ≈ 10.0
+        @test wasserstein([0.0, 0.0], [0.0, 0.0]; p=Inf) == 0.0
         # hand-integrated: segments (0,.2]:|1-10| (.2,.4]:|2-10| (.4,.5]:|3-10|
         # (.5,.6]:|3-20| (.6,.8]:|4-20| (.8,1]:|5-20| ⇒ W₁ = 12
         @test wasserstein([1, 2, 3, 4, 5], [10, 20]) ≈ 12.0
@@ -32,6 +35,13 @@
         # empty samples fail loudly rather than returning NaN
         @test_throws ArgumentError wasserstein(Float64[], [1.0, 2.0])
         @test_throws ArgumentError wasserstein([1.0, 2.0], Float64[])
+
+        # Distribution forms use adaptive quantile integration and distinguish a
+        # genuinely divergent moment from tail cancellation between two laws.
+        @test wasserstein(Cauchy(), Dirac(0.0); p=1) == Inf
+        @test wasserstein(Cauchy(), Cauchy(3, 1); p=1) ≈ 3.0
+        @test wasserstein(Normal(), Normal(3, 1); p=Inf) ≈ 3.0
+        @test_throws ErrorException wasserstein(Normal(), Normal(3, 1); p=Inf, maxevals=64)
     end
 
     @testset "transportmap / pushforward" begin

--- a/test/optimal_transport.jl
+++ b/test/optimal_transport.jl
@@ -42,6 +42,8 @@
         @test wasserstein(Cauchy(), Cauchy(3, 1); p=1) ≈ 3.0
         @test wasserstein(Normal(), Normal(3, 1); p=Inf) ≈ 3.0
         @test wasserstein(Normal(), Normal(0, 2); p=Inf) == Inf
+        @test wasserstein(Uniform(0, 1), Uniform(0, 2); p=Inf) ≈ 1.0
+        @test wasserstein(Uniform(-2, 1), Uniform(0, 2); p=Inf) ≈ 2.0
         @test wasserstein(randn(MersenneTwister(11), 100), Normal(); p=Inf) == Inf
         # The empirical law is bounded, so its W₁ distance from a true Cauchy
         # law is infinite even when the observations themselves came from Cauchy.

--- a/test/risk_measures.jl
+++ b/test/risk_measures.jl
@@ -14,6 +14,8 @@
     end
     @test DualPower(2).v == 2
     @test ProportionalHazard(2).y == 2
+    @test DualPower{Float64}(2).v === 2.0
+    @test ProportionalHazard{Float64}(2).y === 2.0
 
     # https://utstat.utoronto.ca/sam/coorses/act466/rmn.pdf pg 17
     @test RiskMeasures.g(WangTransform(cdf(Normal(), 1)), 1 - cdf(LogNormal(0, 1), 12)) ≈ 0.06879 atol = 1e-5

--- a/test/risk_measures.jl
+++ b/test/risk_measures.jl
@@ -8,6 +8,12 @@
     @test_throws AssertionError CTE(1.5)
     @test_throws AssertionError WangTransform(0.0)
     @test_throws AssertionError WangTransform(1.0)
+    for bad in (0, -1, Inf, NaN)
+        @test_throws ArgumentError DualPower(bad)
+        @test_throws ArgumentError ProportionalHazard(bad)
+    end
+    @test DualPower(2).v == 2
+    @test ProportionalHazard(2).y == 2
 
     # https://utstat.utoronto.ca/sam/coorses/act466/rmn.pdf pg 17
     @test RiskMeasures.g(WangTransform(cdf(Normal(), 1)), 1 - cdf(LogNormal(0, 1), 12)) ≈ 0.06879 atol = 1e-5
@@ -102,4 +108,3 @@
     @test CTE(0.99)(L) ≈ 321.8 atol = 1e-1
 
 end
-


### PR DESCRIPTION
## Summary
- compute empirical W-infinity correctly and replace fixed-grid distribution distances with verified adaptive quantile calculations
- return infinity for demonstrated divergent tails and fail loudly when numerical convergence cannot be established
- reject invalid DualPower and ProportionalHazard parameters
- protect key-rate analytics when cashflows lack corresponding times while allowing extra zero-cashflow time positions

## Validation
- full ActuaryUtilities test suite passed
- Aqua.jl passed
- added regressions for empirical and distributional W-infinity, heavy-tail divergence and cancellation, distortion parameters, and key-rate time lengths