### PR TITLE
Fix divergent risk measures: honest NaN/Inf/throw, lower-quantile VaR, verified quadrature (5.11.2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ActuaryUtilities"
 uuid = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 authors = ["Alec Loudenback"]
-version = "5.11.1"
+version = "5.11.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/risk_measures.md
+++ b/docs/src/risk_measures.md
@@ -100,21 +100,33 @@ Adapting Wang (2002), there are two key components:
 
 This remaps values in the [0,1] range to another value in the [0,1] range, and in $H$ below, operates on the survival function $S$ and $F=1-S$.
 
-Let $g:[0,1]\to[0,1]$ be an increasing function with $g(0)=0$ and $g(1)=1$. The transform $F^*(x)=g(F(x))$ defines a distorted probability distribution, where "$g$" is called a distortion function.
+Let $g:[0,1]\to[0,1]$ be an increasing function with $g(0)=0$ and $g(1)=1$. Applied to the survival function, the transform $S^*(x)=g(S(x))$ defines a distorted probability distribution with $F^*(x) = 1 - g(S(x)) = \bar{g}(F(x))$, where "$g$" is called a distortion function and $\bar{g}(u) = 1 - g(1-u)$ is its complement.
 
 Note that $F^*$ and $F$ are equivalent probability measures if and only if $g:[0,1]\to[0,1]$ is continuous and one-to-one.
-Definition 4.2. We define a family of distortion risk-measures using the mean-value under the distorted probability $F^*(x)=g(F(x))$:
+Definition 4.2. We define a family of distortion risk-measures using the mean-value under the distorted probability:
 
 ### Risk Measure Integration
 
-To calculate a risk measure $H$, we integrate the distorted $F$ across all possible values in the risk distribution (i.e. $x \in X$):
+To calculate a risk measure $H$, we integrate the distorted probabilities across all possible values in the risk distribution (i.e. $x \in X$). Two distortions appear. The survival distortion $g$ acts on the survival function $S(x) = 1 - F(x)$. The complementary distortion $\bar{g}(u) = 1 - g(1-u)$ acts on the distribution function $F$. The risk measure is the Choquet integral
 
-$$H(X) = E^*(X) = - \int_{-\infty}^0 g(F(x))dx + \int_0^{+\infty}[1-g(F(x))]dx$$
+$$H(X) = E^*(X) = \int_0^{+\infty} g(S(x))\,dx - \int_{-\infty}^0 \bar{g}(F(x))\,dx$$
 
 That is, the risk measure ($H$) is equal to the expected value of the distortion of the risk distribution ($E^*(X)$).
 
+Two definitions are fixed by this framework and by this package:
+
+- `VaR(α)` is the lower generalized inverse: $\mathrm{VaR}_\alpha(X) = \inf\{x : F_X(x) \ge \alpha\}$. At an atom, the lower quantile applies: `VaR(0.5)(Bernoulli(0.5)) == 0`.
+- `CTE(α)` is the expected shortfall (average Value at Risk): the mean of exactly the worst $1-\alpha$ of probability mass. When the $\alpha$ boundary falls inside an atom, that atom contributes fractional weight. CTE's atom handling does not depend on the VaR boundary convention.
+
 !!! note "How the computation is performed"
-    When `risk` is a continuous `Distributions.jl` distribution, this integral is evaluated by numerical quadrature of the distorted distribution function. When `risk` is an array of outcomes, the same Choquet integral reduces to a finite weighted sum of the sample's order statistics, and `VaR`, `CTE`, and `Expectation` evaluate that sum exactly (no quadrature or approximation error); the other distortion measures integrate the distorted empirical CDF numerically.
+    The implementation picks the most exact path available, in this order:
+
+    1. **Analytic.** `Expectation` on a distribution uses `Distributions.mean`. Its conventions pass through: `NaN` when the mean does not exist (`Cauchy`), `±Inf` when it diverges (`Pareto` with tail index ≤ 1). `VaR` on a distribution uses `Distributions.quantile`. `CTE` returns `+Inf` when the upper tail expectation diverges.
+    2. **Exact finite sums.** Arrays and finite-support discrete distributions reduce every distortion measure to a finite weighted sum over atoms. There is no quadrature and no approximation error.
+    3. **Checked tail summation.** Integer-valued distributions bounded below with infinite support (`Poisson`, `Geometric`, …) sum atoms with a doubling truncation until successive truncations agree within tolerance.
+    4. **Checked quadrature.** All other cases integrate the distorted distribution with `QuadGK` and enforce the returned error estimate. Quadrature runs at `Float64` precision.
+
+    A checked path throws an `ErrorException` when the reported error cannot be verified against the requested tolerance. That check certifies that the quadrature error estimate met the tolerance; it does not prove the integral exists. Custom distortions should also specialize `ActuaryUtilities.RiskMeasures.gbar` when the generic complement `1 - g(1 - F)` can lose precision.
 
 ## Examples
 

--- a/docs/src/upgrade.md
+++ b/docs/src/upgrade.md
@@ -1,5 +1,45 @@
 # Version Upgrade Guide
 
+## v5.11.1 to v5.11.2
+
+This release fixes a class of bugs where risk measures returned believable but wrong finite numbers. Two behavior changes matter for existing code.
+
+### VaR now uses the standard lower quantile
+
+The old implementation selected the upper quantile at exact atom boundaries. The new `VaR(α)` is the standard generalized inverse, $\inf\{x : F(x) \ge \alpha\}$, everywhere: distributions, arrays, and discrete laws. Values can decrease by a whole atom at exact boundaries. This is an intentional correctness fix, not a numerical drift:
+
+```julia
+VaR(0.5)(Bernoulli(0.5))       # old: 1, new: 0
+VaR(0.95)(collect(1.0:1000.0)) # old: 951, new: 950
+```
+
+Related details:
+
+- `CTE` semantics are unchanged. It still averages exactly the worst `1-α` of probability mass, with fractional weight on the boundary atom.
+- `VaR` on a distribution now returns `Distributions.quantile(risk, α)` and keeps its type — for example an `Int` for a count distribution.
+- `VaR(0)` is the essential infimum. For a distribution with support unbounded below it returns `-Inf`; previously it returned an unconverged quadrature number.
+- `robustvalue`'s adverse scenario for `VaR` now shifts the rank VaR itself selects. Previously, at an exact boundary the shifted set could exclude that rank, and the reported "robust" value equaled the base value.
+
+### Divergent risks return honest values or throw
+
+The old implementation integrated distorted distribution functions with unchecked quadrature and subtracted the two halves. Divergent integrals produced plausible finite numbers:
+
+```julia
+Expectation()(Cauchy())        # old: 0.0,      new: NaN  (mean does not exist)
+Expectation()(Pareto(0.5, 1))  # old: ≈2.9e8,   new: Inf  (mean diverges)
+CTE(0.95)(Cauchy())            # old: ≈215.14,  new: Inf  (tail mean diverges)
+WangTransform(0.9)(Cauchy())   # old: a finite number, new: throws ErrorException
+```
+
+The policy: results that are provably divergent from the distribution's `mean` semantics return `NaN`/`±Inf`; a quadrature result that cannot be verified throws instead of returning a number.
+
+Related details:
+
+- `Expectation`, `VaR`, and `CTE` on distributions are now analytic or exact where possible. Values move within the old quadrature tolerance.
+- All distortion measures on arrays and on discrete distributions (`DiscreteNonParametric`, `Binomial`, `Poisson`, …) now evaluate as exact or checked weighted sums instead of quadrature over step functions.
+- `DualPower` and the internal complementary distortions now use numerically stable forms (`expm1`/`log1p`). The old algebra could silently lose the quadrature error certificate in far tails.
+- Empty arrays now throw an `ArgumentError` for every risk measure.
+
 ## v5.8 to v5.9
 
 Non-breaking unless you relied on the specific edge-case behaviors noted below.

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -317,12 +317,15 @@ loss. What is returned depends on the measure:
 
 - For any other risk measure the result is `rm` evaluated on a concrete adverse
   scenario *inside* the ball: the tail order statistics ``x_{(k)}, \\dots,
-  x_{(n)}`` — the same tail boundary ``k`` that [`VaR`](@ref) and [`CTE`](@ref)
-  use on a sample — are shifted outward by `radius * (m/n)^(-1/p)`, where `m/n`
-  is the fraction of observations shifted, so the scenario costs exactly
-  `radius` in ``W_p``. This is a **lower bound** on the true worst case over the
-  ball, not the supremum itself — treat it as a principled adverse scenario, not
-  a proven maximum.
+  x_{(n)}`` are shifted outward by `radius * (m/n)^(-1/p)`, where `m/n` is the
+  fraction of observations shifted, so the scenario costs exactly `radius` in
+  ``W_p``. The starting rank ``k`` depends on the measure. For [`VaR`](@ref),
+  ``k`` is the rank VaR itself selects: the smallest ``k`` with ``k/n \\ge``
+  `tail`. For every other measure, ``k`` is the first rank with strictly
+  positive [`CTE`](@ref) tail weight: the smallest ``k`` with ``k/n >`` `tail`.
+  The two rules differ exactly at atom boundaries. This is a **lower bound** on
+  the true worst case over the ball, not the supremum itself — treat it as a
+  principled adverse scenario, not a proven maximum.
 
 Because the exact CTE branch applies only when `tail == rm.α`, changing `tail`
 across that equality switches between the atom-splitting exact bound and the
@@ -357,13 +360,17 @@ function robustvalue(rm::RiskMeasure, sample::AbstractVector{<:Real};
     # n*α is not an integer.
     rm isa CTE && tail == rm.α && return rm(sample) + radius * (1 - tail)^(-1 / p)
     # Otherwise evaluate `rm` on a budget-exact adverse scenario: shift the tail
-    # order statistics x_(k)…x_(n) — the SAME boundary `k` that VaR/CTE use on a
-    # sample, so the shifted set matches the measure's own tail even under ties —
-    # outward by Δ sized to the mass m/n actually moved, so the scenario costs
-    # exactly `radius` in W_p and stays inside the ball.
+    # order statistics x_(k)…x_(n) outward by Δ sized to the mass m/n actually
+    # moved, so the scenario costs exactly `radius` in W_p and stays inside the
+    # ball. VaR's scenario must move the rank VaR itself selects (first k with
+    # k/n ≥ tail, the lower quantile); other measures shift the strict tail
+    # (first rank with positive CTE tail weight, k/n > tail). The two rules
+    # differ exactly at atom boundaries: with n=10 and tail=0.5, shifting only
+    # ranks 6:10 would leave VaR at rank 5 unmoved and buy zero loading.
     xs = sort!(float.(sample))                 # promote: Int samples cannot hold x + Δ
     n = length(xs)
-    k = RiskMeasures._first_index_above(n, tail)
+    k = rm isa VaR ? RiskMeasures._first_index_at_or_above(n, tail) :
+        RiskMeasures._first_index_above(n, tail)
     m = n - k + 1
     Δ = radius * (m / n)^(-1 / p)
     @views xs[k:n] .+= Δ

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -397,13 +397,14 @@ end
 # above (Poisson, Geometric, …). Integers outside the support carry zero
 # probability, so their distortion weight is zero and they are skipped; the sum
 # is therefore correct for any integer-valued law. The truncation point doubles
-# until two successive doublings agree within `rtol`; a distorted tail whose
-# sum does not stabilize within the atom budget throws.
+# until (a) the un-scanned distorted tail is provably negligible and (b) two
+# successive doublings agree within `rtol`. A distorted tail whose sum does not
+# stabilize within the atom budget throws.
 function _distorted_tail_sum(rm::RiskMeasure, d, lo::Integer; rtol=sqrt(eps(Float64)), maxatoms=2^24)
     acc = 0.0
     consumed = 0
     N = 32
-    previous = Inf
+    previous = NaN   # NaN comparisons are false: the first pass never counts as stable
     stable = 0
     while N <= maxatoms
         for i in (consumed + 1):N
@@ -415,7 +416,18 @@ function _distorted_tail_sum(rm::RiskMeasure, d, lo::Integer; rtol=sqrt(eps(Floa
         end
         consumed = N
         isfinite(acc) || break
-        if abs(acc - previous) <= rtol * max(abs(acc), abs(previous))
+        # The un-scanned atoms carry total distorted weight g(S(x_N)) at values
+        # at or beyond x_N, so `tailguard` bounds their smallest possible
+        # contribution. Stability alone is not enough: an all-zero prefix
+        # (Poisson(1000) under Wang has ccdf == 1.0 for its first hundreds of
+        # atoms) produces identical truncations long before any mass is seen.
+        # A divergent distorted tail needs g(S(x)) ≳ 1/x infinitely often,
+        # which keeps x·g(S(x)) away from zero — so divergence can never pass
+        # this guard, and the budget-exhaustion throw below fires instead.
+        xN = lo + (N - 1)
+        wrem = abs(g(rm, clamp(Distributions.ccdf(d, xN), 0.0, 1.0)))
+        tolerance = rtol * max(1.0, abs(acc))
+        if wrem * max(1.0, abs(xN)) <= tolerance && abs(acc - previous) <= tolerance
             stable += 1
             stable >= 2 && return acc
         else

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -8,13 +8,28 @@ export Expectation, VaR, ValueAtRisk, CTE, ConditionalTailExpectation, WangTrans
 abstract type RiskMeasure end
 
 """
-    g(rm::RiskMeasure,x)
+    g(rm::RiskMeasure, x)
 
 The probability distortion function associated with the given risk measure.
+The argument `x` is a survival probability in `[0, 1]`. The result is the
+distorted survival probability.
 
 See [Distortion Function g(u)](@ref)
 """
 function g(rm::RiskMeasure, x) end
+
+"""
+    gbar(rm::RiskMeasure, F)
+
+The complementary distortion function. It satisfies `gbar(rm, F) == 1 - g(rm, 1 - F)`.
+The argument `F` is a cumulative probability in `[0, 1]`.
+
+The generic fallback computes `1 - g(rm, 1 - F)` directly. That expression can
+lose all precision when `F` is small, because `1 - F` rounds to `1`. Specialize
+`gbar` for a custom risk measure when a stable form exists. This package
+specializes `gbar` for every built-in measure.
+"""
+gbar(rm::RiskMeasure, F) = 1 - g(rm, 1 - F)
 
 """
     Expectation()::RiskMeasure
@@ -23,6 +38,15 @@ function g(rm::RiskMeasure, x) end
 The expected value of the risk.
 
 `Expectation()` returns a functor which can then be called on a risk distribution.
+
+For a `Distributions.UnivariateDistribution`, the result is the analytic
+`Distributions.mean` when the distribution defines one. The mean's conventions
+pass through: the result is `NaN` when the mean does not exist (for example
+`Cauchy`), and `±Inf` when the mean diverges (for example `Pareto` with tail
+index at or below 1). A finite-support discrete distribution is evaluated as an
+exact weighted sum. A distribution without its own `mean` method (for example a
+generic `truncated` wrapper) is evaluated by checked numerical quadrature; that
+path throws an error when the quadrature error cannot be verified.
 
 ## Examples
 
@@ -39,18 +63,36 @@ julia> rm(rand(1000))
 """
 struct Expectation <: RiskMeasure end
 g(rm::Expectation, x) = x
+gbar(rm::Expectation, F) = F
 
 """
      VaR(α)::RiskMeasure
      VaR(α)(risk)::T (where T is the type of values sampled in `risk`)
 
-The `α`th quantile of the `risk` distribution is the Value at Risk, or αth quantile. `risk` can be a univariate distribution or an array of outcomes.
-Assumes more positive values are higher risk measures, so a higher p will return a more positive number. For a discrete risk, the VaR returned is the first value above the αth percentile.
+The Value at Risk at level `α`: the lower generalized inverse of the
+distribution function,
+
+``\\mathrm{VaR}_\\alpha(X) = \\inf\\{x : F_X(x) \\ge \\alpha\\}.``
+
+`risk` can be a univariate distribution or an array of outcomes.
+Assumes more positive values are higher risk measures, so a higher `α` will
+return a more positive number.
+
+- For a distribution, the result is `Distributions.quantile(risk, α)`. The
+  result keeps `quantile`'s numeric type (for example an integer for a count
+  distribution).
+- For an array of `n` outcomes, the result is the first order statistic whose
+  rank `k` satisfies `k/n ≥ α`.
+- At an atom of the distribution, the lower quantile applies. Example:
+  `VaR(0.5)(Bernoulli(0.5)) == 0`.
+- `VaR(0)` is the essential infimum: the sample minimum for an array, and
+  `quantile(risk, 0)` for a distribution (`-Inf` when the support is unbounded
+  below).
 
 `VaR(α)` returns a functor which can then be called on a risk distribution.
 
 ## Parameters
-- α: [0,1.0) 
+- α: [0,1.0)
 
 ## Examples
 
@@ -73,7 +115,10 @@ struct VaR{T<:Real} <: RiskMeasure
         return new{T}(α)
     end
 end
-g(rm::VaR, x) = x < (1 - rm.α) ? 0 : 1
+# The boundary uses `<=` so that the Choquet form of this distortion selects the
+# lower quantile at an atom, matching `Distributions.quantile`.
+g(rm::VaR, x) = x <= (1 - rm.α) ? 0 : 1
+gbar(rm::VaR, F) = F < rm.α ? 0 : 1
 
 """
 [`VaR`](@ref)
@@ -84,14 +129,32 @@ const ValueAtRisk = VaR
     CTE(α)::RiskMeasure
     CTE(α)(risk)::T (where T is the type of values sampled in risk)
 
-The Conditional Tail Expectation (CTE) at level α is the expected value of the risk distribution above the αth quantile. `risk` can be a univariate distribution or an array of outcomes.
-Assumes more positive values are higher risk measures, so a higher p will return a more positive number.
+The Conditional Tail Expectation (also called expected shortfall or average
+Value at Risk) at level `α`: the mean of exactly the worst `1 - α` of the
+probability mass. When the `α` boundary falls inside an atom, that atom
+contributes fractional weight, so the averaged mass is always exactly `1 - α`.
+CTE's atom handling does not depend on the `VaR` boundary convention.
+
+`risk` can be a univariate distribution or an array of outcomes.
+Assumes more positive values are higher risk measures, so a higher `α` will
+return a more positive number.
+
+- `CTE(0)` is the mean, with the same conventions as [`Expectation`](@ref).
+- The result is `+Inf` when the upper tail expectation diverges. The
+  implementation reads the distribution's `mean` to decide this: `mean == +Inf`
+  means the upper tail diverges; `mean` of `NaN` means both tails diverge.
+  These are the `Distributions.jl` conventions. A `mean` of `-Inf` does not
+  trigger this shortcut, because the upper tail can still be finite.
+- Arrays and finite-support discrete distributions are evaluated as exact
+  weighted sums. Continuous distributions use a checked quadrature of the
+  quantile function. The checked path throws an error when the quadrature
+  error cannot be verified against the requested tolerance.
 
 CTE(α) returns a functor which can then be called on a risk distribution.
 
 ## Parameters
 
-- α: [0,1.0) 
+- α: [0,1.0)
 
 ## Examples
 
@@ -115,6 +178,7 @@ struct CTE{T<:Real} <: RiskMeasure
     end
 end
 g(rm::CTE, x) = x < (1 - rm.α) ? x / (1 - rm.α) : 1
+gbar(rm::CTE, F) = F <= rm.α ? zero(F / (1 - rm.α)) : (F - rm.α) / (1 - rm.α)
 
 """
 [`CTE`](@ref)
@@ -128,6 +192,10 @@ const ConditionalTailExpectation = CTE
 The Wang Transform is a distortion risk measure that transforms the cumulative distribution function (CDF) of the risk distribution using a normal distribution with mean Φ⁻¹(α) and standard deviation 1. risk can be a univariate distribution or an array of outcomes.
 
 WangTransform(α) returns a functor which can then be called on a risk distribution.
+
+For a distribution that is not discrete, the value is computed by checked
+numerical quadrature. That path throws an error when the defining integral
+cannot be verified to converge, for example for heavy-tailed risks.
 
 ## Parameters
 - α: [0,1.0]
@@ -162,6 +230,10 @@ function g(rm::WangTransform, x)
     Φ_inv(x) = Distributions.quantile(Distributions.Normal(), x)
     Distributions.cdf(Distributions.Normal(), Φ_inv(x) + Φ_inv(rm.α))
 end
+function gbar(rm::WangTransform, F)
+    Φ_inv(x) = Distributions.quantile(Distributions.Normal(), x)
+    Distributions.cdf(Distributions.Normal(), Φ_inv(F) - Φ_inv(rm.α))
+end
 
 """
     DualPower(v)::RiskMeasure
@@ -171,6 +243,9 @@ The Dual Power distortion risk measure is defined as ``1 - (1 - x)^v``, where x 
 
 DualPower(v) returns a functor which can then be called on a risk distribution.
 
+For a distribution that is not discrete, the value is computed by checked
+numerical quadrature. That path throws an error when the defining integral
+cannot be verified to converge, for example for heavy-tailed risks.
 """
 struct DualPower{T} <: RiskMeasure
     v::T
@@ -180,7 +255,11 @@ struct DualPower{T} <: RiskMeasure
     end
 end
 DualPower{T}(v) where {T} = DualPower(convert(T, v))
-g(rm::DualPower, x) = 1 - (1 - x)^rm.v
+# `-expm1(v * log1p(-x))` equals `1 - (1 - x)^v` but stays accurate for tiny x,
+# where the direct form rounds to a hard zero and silently invalidates the
+# quadrature error estimate.
+g(rm::DualPower, x) = -expm1(rm.v * log1p(-x))
+gbar(rm::DualPower, F) = F^rm.v
 
 """
     ProportionalHazard(y)::RiskMeasure
@@ -188,6 +267,10 @@ g(rm::DualPower, x) = 1 - (1 - x)^rm.v
 
 The Proportional Hazard distortion risk measure is defined as ``x^(1/y)``, where x is the cumulative distribution function (CDF) of the risk distribution and y is a positive parameter. risk can be a univariate distribution or an array of outcomes.
 ProportionalHazard(y) returns a functor which can then be called on a risk distribution.
+
+For a distribution that is not discrete, the value is computed by checked
+numerical quadrature. That path throws an error when the defining integral
+cannot be verified to converge, for example for heavy-tailed risks.
 
 ## Examples
 
@@ -211,26 +294,152 @@ struct ProportionalHazard{T} <: RiskMeasure
 end
 ProportionalHazard{T}(y) where {T} = ProportionalHazard(convert(T, y))
 g(rm::ProportionalHazard, x) = x^(1 / rm.y)
+gbar(rm::ProportionalHazard, F) = -expm1(log1p(-F) / rm.y)
 
+# ── Distortion-measure evaluation ───────────────────────────────────────────
+#
+# Definition 4.2 of "A Risk Measure that Goes Beyond Coherence", Wang 2002:
+# the Choquet integral
+#
+#   ρ(X) = ∫₀^∞ g(S(x)) dx − ∫_{−∞}^0 ḡ(F(x)) dx,   ḡ(F) = 1 − g(1 − F).
+#
+# Evaluation tiers, most exact first:
+#   1. finite-support discrete laws → exact distortion-weighted sums
+#   2. integer-valued laws bounded below (Poisson, Geometric, …) → checked
+#      tail summation
+#   3. everything else → checked quadrature whose error estimate is enforced.
+# A risk whose distorted expectation cannot be verified throws instead of
+# returning a silently wrong number.
 function (rm::RiskMeasure)(risk)
-    # Definition 4.2 of "A Risk Measure that Goes Beyond Coherence", Wang 2002
-    F(x) = cdf_func(risk)(x)
-    H(x) = 1 - g(rm, 1 - x)
-    integral1, _ = QuadGK.quadgk(x -> 1 - H(F(x)), 0, Inf)
-    integral2, _ = QuadGK.quadgk(x -> H(F(x)), -Inf, 0)
-    return integral1 - integral2
+    if risk isa Distributions.DiscreteUnivariateDistribution
+        _finite_atoms(risk) && return _distorted_sum(rm, _atoms(risk)...)
+        lo = minimum(risk)
+        (eltype(risk) <: Integer && isfinite(lo)) && return _distorted_tail_sum(rm, risk, lo)
+    end
+    return _choquet(rm, risk)
+end
+
+# `hasfinitesupport` reports whether the support VALUES are bounded, so it is
+# false for a DiscreteNonParametric with an atom at ±Inf even though the atom
+# COUNT is finite. The exact sum only needs finitely many atoms.
+_finite_atoms(d::Distributions.DiscreteUnivariateDistribution) =
+    d isa Distributions.DiscreteNonParametric || Distributions.hasfinitesupport(d)
+
+function _choquet(rm::RiskMeasure, risk; rtol=sqrt(eps(Float64)), atol=0.0, maxevals=10^7)
+    (isfinite(rtol) && rtol >= 0) || throw(ArgumentError("rtol must be finite and nonnegative"))
+    (isfinite(atol) && atol >= 0) || throw(ArgumentError("atol must be finite and nonnegative"))
+    maxevals > 0 || throw(ArgumentError("maxevals must be positive"))
+    G = ccdf_func(risk)   # hoisted: each closure is built once, not once per node
+    F = cdf_func(risk)
+    # Each side runs at half the requested tolerance. The two certificates then
+    # add up to at most the requested tolerance at the components' scale, so the
+    # final acceptance check below cannot fail on converged components.
+    upper, uerr = QuadGK.quadgk(x -> g(rm, G(x)), 0, Inf; rtol=rtol / 2, atol=atol / 2, maxevals)
+    lower, lerr = QuadGK.quadgk(x -> gbar(rm, F(x)), -Inf, 0; rtol=rtol / 2, atol=atol / 2, maxevals)
+    _check_component(upper, uerr, rtol / 2, atol / 2)
+    _check_component(lower, lerr, rtol / 2, atol / 2)
+    result = upper - lower
+    # Cancellation-aware final check. The result's absolute error is at most
+    # uerr + lerr; certify it at the scale of the components, not only the
+    # (possibly near-zero) difference. This certifies that the quadrature error
+    # met the requested tolerance; it does not prove the integral exists.
+    err_total = uerr + lerr
+    tolerance = max(atol, rtol * abs(result), rtol * max(upper, lower))
+    err_total <= tolerance || throw(ErrorException(
+        "distortion risk measure quadrature could not verify the result: combined error estimate $err_total exceeds tolerance $tolerance"))
+    return result
+end
+
+# Reject every unverifiable quadrature output: a NaN or infinite integral, a
+# NaN or negative error estimate, or an error above tolerance. NaN comparisons
+# are false, so `isfinite(err)` must be checked explicitly.
+function _check_component(I, err, rtol, atol)
+    (isfinite(I) && isfinite(err) && err >= 0 && err <= max(atol, rtol * abs(I))) ||
+        throw(ErrorException(
+            "distortion risk measure quadrature did not converge (integral ≈ $I, estimated error $err): " *
+            "the distorted expectation may not exist for this risk (e.g. heavy tails such as Cauchy, or Pareto with tail index ≤ 1)"))
+    return nothing
+end
+
+# ── Exact atomic evaluation ─────────────────────────────────────────────────
+#
+# For a purely atomic law {(xᵢ, pᵢ)} with sorted atoms, the Choquet integral is
+# a finite distortion-weighted sum: with S(xᵢ⁻) = P(X ≥ xᵢ),
+#
+#   ρ = Σᵢ xᵢ · (g(S(xᵢ⁻)) − g(S(xᵢ))).
+#
+# No quadrature crosses the cdf's jump discontinuities, so the sum is exact.
+
+function _atoms(d::Distributions.DiscreteUnivariateDistribution)
+    xs = collect(Distributions.support(d))   # sorted; `collect` also handles Dirac's tuple
+    return xs, Distributions.pdf.(d, xs)
+end
+
+function _distorted_sum(rm::RiskMeasure, xs, ps)
+    total = sum(ps)
+    (isfinite(total) && total > 0) || throw(ArgumentError("atom probabilities must have a positive finite sum, got $total"))
+    n = length(xs)
+    T = float(promote_type(eltype(xs), eltype(ps)))
+    # Survival values are normalized by the actual total and clamped into
+    # [0, 1]: even a pristine Binomial pdf sums to 1 + 7e-16, which would push
+    # a reverse cumsum above 1 and break distortions such as Φ⁻¹.
+    tailp = reverse!(cumsum(reverse(ps)))
+    S(i) = i == 1 ? one(T) : i > n ? zero(T) : clamp(T(tailp[i]) / total, zero(T), one(T))
+    return sum(eachindex(xs)) do i
+        w = g(rm, S(i)) - g(rm, S(i + 1))
+        # Skip zero weights before multiplying: an atom at ±Inf with zero
+        # distorted weight must not turn the sum into NaN through Inf * 0.
+        iszero(w) ? zero(T) : T(xs[i] * w)
+    end
+end
+
+# Checked tail summation for integer-valued laws that are bounded below but not
+# above (Poisson, Geometric, …). Integers outside the support carry zero
+# probability, so their distortion weight is zero and they are skipped; the sum
+# is therefore correct for any integer-valued law. The truncation point doubles
+# until two successive doublings agree within `rtol`; a distorted tail whose
+# sum does not stabilize within the atom budget throws.
+function _distorted_tail_sum(rm::RiskMeasure, d, lo::Integer; rtol=sqrt(eps(Float64)), maxatoms=2^24)
+    acc = 0.0
+    consumed = 0
+    N = 32
+    previous = Inf
+    stable = 0
+    while N <= maxatoms
+        for i in (consumed + 1):N
+            x = lo + (i - 1)
+            Sminus = i == 1 ? 1.0 : clamp(Distributions.ccdf(d, x - 1), 0.0, 1.0)
+            S = clamp(Distributions.ccdf(d, x), 0.0, 1.0)
+            w = g(rm, Sminus) - g(rm, S)
+            iszero(w) || (acc += x * w)
+        end
+        consumed = N
+        isfinite(acc) || break
+        if abs(acc - previous) <= rtol * max(abs(acc), abs(previous))
+            stable += 1
+            stable >= 2 && return acc
+        else
+            stable = 0
+        end
+        previous = acc
+        N *= 2
+    end
+    throw(ErrorException(
+        "distortion risk measure tail sum did not converge within $maxatoms atoms: the distorted expectation may not exist for this risk"))
 end
 
 # ── Exact empirical specializations ─────────────────────────────────────────
 #
-# For a finite sample the Choquet integral above reduces to order statistics:
+# For a finite sample the Choquet integral reduces to order statistics:
 # computing it by adaptive quadrature over the ecdf's step function is both
 # orders of magnitude slower and exposes integration tolerance at the steps.
 # These methods evaluate the same functional exactly.
 #
-# With the empirical cdf F(x_(k)) = k/n, the "first value above the αth
-# percentile" is the order statistic x_(k) with k the smallest index such that
-# k/n > α.
+# Two boundary rules serve different purposes and both are needed:
+#   * `_first_index_above`      — smallest k with k/n > α. CTE uses it: the
+#     first rank with strictly positive tail weight.
+#   * `_first_index_at_or_above` — smallest k with k/n ≥ α. VaR uses it: the
+#     lower quantile of the empirical distribution.
 function _first_index_above(n, α)
     k = clamp(floor(Int, n * α) + 1, 1, n)
     # floating-point n*α can land on either side of an exact boundary; nudge so
@@ -244,26 +453,120 @@ function _first_index_above(n, α)
     return k
 end
 
+function _first_index_at_or_above(n, α)
+    k = clamp(ceil(Int, n * α), 1, n)
+    # same float-boundary nudging, for the ≥ rule
+    while k > 1 && (k - 1) / n >= α
+        k -= 1
+    end
+    while k < n && k / n < α
+        k += 1
+    end
+    return k
+end
+
+# The generic exact sum for an equally weighted sample serves the distortion
+# measures without a dedicated fast path (WangTransform, DualPower,
+# ProportionalHazard, user-defined). The VaR/CTE/Expectation methods below are
+# more specific and intercept first.
+function (rm::RiskMeasure)(risk::AbstractArray{<:Real})
+    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
+    xs = sort(vec(risk))
+    n = length(xs)
+    T = float(eltype(xs))
+    return sum(eachindex(xs)) do i
+        w = g(rm, T(n - i + 1) / n) - g(rm, T(n - i) / n)
+        iszero(w) ? zero(T) : T(xs[i] * w)
+    end
+end
+
 function (rm::VaR)(risk::AbstractArray{<:Real})
+    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
     n = length(risk)
-    k = _first_index_above(n, rm.α)
+    k = _first_index_at_or_above(n, rm.α)
     return partialsort(vec(risk), k)
 end
 
 # The Choquet-CTE distorts the tail by 1/(1-α): the crossing order statistic
 # x_(k) receives the partial weight (k/n - α), and each of x_(k+1)…x_(n)
 # receives 1/n, all normalized by (1-α). (CTE(0) is then exactly the mean.)
+# Elements are divided by n before summing so that large samples cannot
+# overflow the accumulator.
 function (rm::CTE)(risk::AbstractArray{<:Real})
+    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
     n = length(risk)
     α = rm.α
     k = _first_index_above(n, α)
     tail = partialsort(vec(risk), k:n)
-    partial = (k / n - α) * first(tail)
-    rest = sum(@view tail[2:end]) / n
+    T = float(promote_type(eltype(risk), typeof(α)))
+    partial = (T(k) / n - α) * first(tail)
+    rest = sum(x -> T(x) / n, @view(tail[2:end]); init=zero(T))
     return (partial + rest) / (1 - α)
 end
 
-(rm::Expectation)(risk::AbstractArray{<:Real}) = sum(risk) / length(risk)
+function (rm::Expectation)(risk::AbstractArray{<:Real})
+    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
+    n = length(risk)
+    return sum(x -> x / n, risk)
+end
+
+# ── Exact distributional specializations ────────────────────────────────────
+
+# A distribution "has a mean" exactly when its `which` match is not Statistics'
+# generic `mean(itr)` fallback (which a distribution cannot satisfy — it throws
+# a MethodError at `iterate`). Errors raised inside a real `mean` method still
+# propagate; only the absence of a specific method routes to quadrature.
+_mean_available(d) =
+    which(Distributions.mean, Tuple{typeof(d)}) !== which(Distributions.mean, Tuple{Any})
+
+function (rm::Expectation)(risk::Distributions.UnivariateDistribution)
+    if risk isa Distributions.DiscreteUnivariateDistribution && _finite_atoms(risk)
+        # exact weighted sum; the identity distortion makes this Σ xᵢpᵢ with
+        # zero-probability atoms skipped (an Inf atom with p = 0 must not
+        # produce NaN, as `mean` would)
+        return _distorted_sum(rm, _atoms(risk)...)
+    end
+    _mean_available(risk) && return Distributions.mean(risk)   # NaN / ±Inf pass through
+    return _choquet(rm, risk)   # e.g. truncated wrappers without a `mean` method
+end
+
+# The VaR distortion collapses the Choquet integral to the lower α-quantile,
+# which `Distributions.quantile` already implements for every distribution.
+(rm::VaR)(risk::Distributions.UnivariateDistribution) = Distributions.quantile(risk, rm.α)
+
+function (rm::CTE)(risk::Distributions.UnivariateDistribution)
+    α = rm.α
+    if risk isa Distributions.DiscreteUnivariateDistribution && _finite_atoms(risk)
+        return _distorted_sum(rm, _atoms(risk)...)   # exact fractional-atom tail sum
+    end
+    m = _mean_available(risk) ? Distributions.mean(risk) : nothing
+    if iszero(α)
+        # CTE(0) is the mean. This runs before any divergence shortcut so that
+        # CTE(0)(Cauchy()) is NaN, matching Expectation.
+        return isnothing(m) ? _choquet(rm, risk) : m
+    end
+    if !isnothing(m) && (m == Inf || isnan(m))
+        # Distributions.jl conventions: mean == +Inf means the upper tail
+        # diverges; mean == NaN means both tails diverge. Either way
+        # E[X⁺] = ∞, so CTE_α = +∞ for α > 0. A mean of -Inf is NOT a
+        # shortcut: only the lower tail diverges and the CTE stays finite.
+        return Inf
+    end
+    if risk isa Distributions.DiscreteUnivariateDistribution
+        lo = minimum(risk)
+        (eltype(risk) <: Integer && isfinite(lo)) && return _distorted_tail_sum(rm, risk, lo)
+    end
+    # Expected shortfall as a single one-sided quantile integral:
+    #   CTE_α = (1/(1-α)) ∫_α^1 quantile(u) du.
+    # There is no subtraction, so no cancellation: the certified error below
+    # controls the error of the final result after dividing by (1-α).
+    rtol, atol, maxevals = sqrt(eps(Float64)), 0.0, 10^7
+    I, err = QuadGK.quadgk(u -> Distributions.quantile(risk, u), α, 1; rtol, atol, maxevals)
+    (isfinite(I) && isfinite(err) && err >= 0 && err <= max(atol * (1 - α), rtol * abs(I))) ||
+        throw(ErrorException(
+            "CTE quantile integral did not converge (integral ≈ $I, estimated error $err): E[X⁺] may be infinite for this risk"))
+    return I / (1 - α)
+end
 
 """
     cdf_func(risk)
@@ -276,5 +579,22 @@ Returns the appropriate cumulative distribution function depending on the type, 
 """
 cdf_func(S::AbstractArray{<:Real}) = StatsBase.ecdf(S)
 cdf_func(S::Distributions.UnivariateDistribution) = x -> Distributions.cdf(S, x)
+
+"""
+    ccdf_func(risk)
+
+Survival-function counterpart of [`cdf_func`](@ref):
+
+    ccdf_func(S::Distributions.UnivariateDistribution) = x -> Distributions.ccdf(S, x)
+
+Other risk types fall back to `x -> 1 - F(x)` with `F = cdf_func(S)` built
+once. The distribution method uses `ccdf` directly because `1 - cdf(x)` loses
+all precision in the far tail, where `cdf(x)` rounds to `1`.
+"""
+ccdf_func(S::Distributions.UnivariateDistribution) = x -> Distributions.ccdf(S, x)
+function ccdf_func(S)
+    F = cdf_func(S)
+    return x -> 1 - F(x)
+end
 
 end

--- a/test/audit.jl
+++ b/test/audit.jl
@@ -97,7 +97,8 @@ end
 
 @testset "risk measure exact empirical estimators" begin
     L = collect(1.0:1000.0)
-    @test VaR(0.95)(L) == 951.0
+    # VaR is the lower empirical quantile: the smallest k with k/n ≥ α
+    @test VaR(0.95)(L) == 950.0
     @test VaR(0.0)(L) == 1.0
     @test CTE(0.0)(L) ≈ sum(L) / 1000
     # CTE Choquet weights: crossing atom gets (k/n - α), the rest 1/n, all / (1-α)
@@ -109,12 +110,12 @@ end
     # duplicates / plateaus are handled exactly (quadrature used to wobble here)
     dup = [1.0, 1.0, 1.0, 1.0, 2.0]
     @test VaR(0.5)(dup) == 1.0
-    @test VaR(0.8)(dup) == 2.0
+    @test VaR(0.8)(dup) == 1.0   # k = 4 satisfies 4/5 ≥ 0.8, so the tied atom is selected
     @test CTE(0.8)(dup) ≈ 2.0
 
     # unsorted input
     shuffled = shuffle(Xoshiro(1), L)
-    @test VaR(0.95)(shuffled) == 951.0
+    @test VaR(0.95)(shuffled) == 950.0
     @test CTE(0.95)(shuffled) ≈ expected
 
     # the exact estimator agrees with the (quadrature) Choquet definition it replaces

--- a/test/optimal_transport.jl
+++ b/test/optimal_transport.jl
@@ -149,6 +149,31 @@
             @test s0 == s1
         end
 
+        # VaR's adverse scenario shifts the rank VaR itself selects. At an exact
+        # atom boundary (n=10, tail=0.5) the strict rule would shift only ranks
+        # 6:10 and leave VaR at rank 5 unmoved — zero loading.
+        let sm = collect(1.0:10.0)
+            @test VaR(0.5)(sm) == 5.0                 # rank 5 under the ≥ rule
+            rv = robustvalue(VaR(0.5), sm; radius=1.0, p=2)
+            @test rv > VaR(0.5)(sm)                   # loading is strictly positive
+            # selected rank k=5, so m=6 and Δ = 1·(6/10)^(-1/2)
+            @test rv ≈ 5.0 + 1.0 * (6 / 10)^(-1 / 2)
+            # the constructed scenario spends exactly the W_p budget
+            sc = [sm[1:4]; sm[5:10] .+ 1.0 * (6 / 10)^(-1 / 2)]
+            @test wasserstein(sc, sm; p=2) ≈ 1.0 rtol = 1e-12
+            # non-VaR measures keep the strict boundary: k=6, m=5
+            scw = [sm[1:5]; sm[6:10] .+ 1.0 * (5 / 10)^(-1 / 2)]
+            @test robustvalue(WangTransform(0.5), sm; radius=1.0, p=2, tail=0.5) ≈
+                  WangTransform(0.5)(scw)
+        end
+
+        # ties at the boundary: the shifted set still contains VaR's selected atom
+        let st = [1.0, 1.0, 1.0, 1.0, 2.0]            # VaR(0.8) selects rank 4 (value 1.0)
+            rv = robustvalue(VaR(0.8), st; radius=0.5, p=1)
+            @test rv > VaR(0.8)(st)
+            @test rv ≈ 1.0 + 0.5 * (2 / 5)^(-1)       # k=4, m=2, Δ = 0.5·(5/2)
+        end
+
         # composes with any risk measure; a measure without a natural tail needs `tail`.
         # (WangTransform has no fast array method, so use a small sample here.)
         @test robustvalue(VaR(0.95), s; radius=100) ≥ VaR(0.95)(s)

--- a/test/risk_measures.jl
+++ b/test/risk_measures.jl
@@ -1,3 +1,16 @@
+# Test scaffolding for dispatch tests. Structs cannot be defined inside a
+# @testset, so these live at the top level.
+
+# A distribution whose own `mean` method throws. The error must propagate; the
+# implementation must not silently reroute to quadrature.
+struct BrokenMeanDist <: ContinuousUnivariateDistribution end
+Distributions.mean(::BrokenMeanDist) = sum(nothing)
+
+# A risk type whose cdf is NaN everywhere. Checked quadrature must throw, not
+# return a silent number.
+struct NaNCDFRisk end
+ActuaryUtilities.RiskMeasures.cdf_func(::NaNCDFRisk) = x -> NaN
+
 @testset "Risk Measures" begin
 
     @test_throws AssertionError VaR(-0.5)
@@ -85,8 +98,9 @@
     end
 
     # Hardy, "An Introduction to Risk Measures for Actuarial Applications
-    # note the difference for VaR where our VaR is L(Nα+1), as opposed to L(Nα) 
-    # or the smoothed empirical estimate
+    # note the difference for VaR: our VaR is L(⌈Nα⌉), the smallest k with
+    # k/N ≥ α (the lower empirical quantile), as opposed to the smoothed
+    # empirical estimate
 
     # Also, confusingly the examples for VaR don't use the same Table 1 (L) as CTE
     L = append!(vec([
@@ -102,11 +116,130 @@
             287.9 298.7 301.6 305.0 313.0 323.8 334.5 343.5 350.3 359.4
         ]), zeros(900)) |> sort
 
-    @test VaR(0.950)(L) ≈ L[951] atol = 1e-2
+    @test VaR(0.950)(L) ≈ L[950] atol = 1e-2
     @test VaR(0.9505)(L) ≈ L[951] atol = 1e-2
-    @test VaR(0.951)(L) ≈ L[952] atol = 1e-2
-    @test VaR(0.95)(L) ≈ L[951] atol = 1e-2
+    @test VaR(0.951)(L) ≈ L[951] atol = 1e-2
+    @test VaR(0.95)(L) ≈ L[950] atol = 1e-2
     @test CTE(0.95)(L) ≈ 260.68 atol = 1e-1
     @test CTE(0.99)(L) ≈ 321.8 atol = 1e-1
+
+    @testset "lower-quantile VaR" begin
+        @test VaR(0.5)(Bernoulli(0.5)) == 0
+        @test VaR(0.95)(collect(1.0:1000.0)) == 950
+        @test VaR(0.8)([1.0, 1.0, 1.0, 1.0, 2.0]) == 1
+        @test VaR(prevfloat(0.95))(collect(1.0:1000.0)) == 950
+        @test VaR(nextfloat(0.95))(collect(1.0:1000.0)) == 951
+        # parity: named discrete law ≡ equal-weight atomic representation ≡ quantile
+        b = Binomial(10, 0.3)
+        bdnp = DiscreteNonParametric(collect(support(b)), pdf.(b, support(b)))
+        for α in (0.0, 0.2, 0.65, 0.99)
+            @test VaR(α)(b) == VaR(α)(bdnp) == quantile(b, α)
+        end
+        # exact atom boundaries use F ≥ α (the lower quantile). A one-ulp step
+        # above the boundary is not assertable for named laws: Distributions'
+        # `quantile` is only cdf-consistent to within a ulp, so probe the
+        # midpoint of the cdf gap instead.
+        F3 = cdf(b, 3)
+        @test VaR(F3)(b) == 3
+        @test VaR(prevfloat(F3))(b) == 3
+        @test VaR((F3 + cdf(b, 4)) / 2)(b) == 4
+        @test VaR(0.6)(A) == 0.0            # cdf(A, 0) == 0.6 exactly
+        @test VaR(nextfloat(0.6))(A) == 1.0
+        @test VaR(0.95)(A) == 1.0
+        # VaR(0) is the essential infimum
+        @test VaR(0.0)(Normal()) == -Inf
+        @test VaR(0.0)(Pareto(1.5, 1)) == 1.0
+        @test VaR(0.0)([3.0, 1.0, 2.0]) == 1.0
+    end
+
+    @testset "divergent / heavy-tailed risks" begin
+        @test isnan(RiskMeasures.Expectation()(Cauchy()))
+        @test RiskMeasures.Expectation()(Pareto(0.5, 1.0)) == Inf
+        @test isnan(CTE(0.0)(Cauchy()))     # α = 0 runs before any divergence shortcut
+        @test CTE(0.95)(Cauchy()) == Inf
+        @test CTE(0.5)(Pareto(0.5, 1.0)) == Inf
+        @test CTE(0.95)(Pareto(1.0, 1.0)) == Inf
+        # mean == -Inf is not a divergence shortcut: the upper tail is finite here
+        @test CTE(0.001)(-1 * Pareto(0.5, 1.0)) ≈ -1000
+        @test VaR(0.95)(Cauchy()) == quantile(Cauchy(), 0.95)
+        # a distorted expectation that cannot be verified throws instead of
+        # returning a plausible finite number
+        @test_throws ErrorException WangTransform(0.9)(Cauchy())
+        @test_throws ErrorException ProportionalHazard(2)(Pareto(0.5, 1.0))
+        @test_throws ErrorException DualPower(2)(Pareto(0.5, 1.0))
+    end
+
+    @testset "stable distortions and certified quadrature" begin
+        # the naive 1-(1-x)^v distortion returns ≈4.4999861 here while its
+        # quadrature error certificate claims ≈7e-8 — the stable form keeps the
+        # certificate honest
+        @test DualPower(2)(Pareto(1.5, 1)) ≈ 4.5 rtol = 1e-6
+        @test WangTransform(0.9)(Normal(0, 1)) ≈ quantile(Normal(), 0.9) rtol = 1e-6
+        # two nearly equal one-sided integrals cancel to ~0; the acceptance rule
+        # certifies at the components' scale instead of throwing
+        @test abs(WangTransform(0.5)(Normal(0, 1))) < 1e-8
+        # gbar is the stable complement of g
+        for rm in (WangTransform(0.9), DualPower(2), ProportionalHazard(2), CTE(0.9), VaR(0.9))
+            for F in (0.2, 0.5, 0.9)
+                @test RiskMeasures.gbar(rm, F) ≈ 1 - RiskMeasures.g(rm, 1 - F) atol = 1e-15
+            end
+        end
+    end
+
+    @testset "atomic robustness" begin
+        # Distributions accepts probability vectors off by ~1e-8; survival values
+        # must be normalized and clamped or Φ⁻¹(1 + ε) throws a DomainError
+        sloppy = DiscreteNonParametric([1.0, 2.0, 3.0], [0.1, 0.2, 0.7000000001])
+        @test isfinite(WangTransform(0.95)(sloppy))
+        # zero-probability atoms at ±Inf must not poison the sum through Inf * 0
+        @test VaR(0.5)(DiscreteNonParametric([0.0, Inf], [0.9, 0.1])) == 0
+        @test RiskMeasures.Expectation()(DiscreteNonParametric([1.0, Inf], [1.0, 0.0])) == 1.0
+        # an equal-weight sample and its atomic representation agree for a
+        # distortion with no dedicated fast path
+        xs = [0.0, 1.0, 5.0]
+        @test WangTransform(0.9)(xs) ≈ WangTransform(0.9)(DiscreteNonParametric(xs, fill(1 / 3, 3)))
+        # finite-support named laws ≡ their atomic representations
+        for d in (Binomial(10, 0.3), DiscreteUniform(1, 6), Bernoulli(0.3), Dirac(2.5))
+            atoms = collect(support(d))
+            dnp = DiscreteNonParametric(atoms, pdf.(d, atoms))
+            @test WangTransform(0.9)(d) ≈ WangTransform(0.9)(dnp)
+            @test CTE(0.9)(d) ≈ CTE(0.9)(dnp)
+        end
+        # infinite-support discrete laws: checked tail summation, cross-checked
+        # against an explicit truncation (tail mass beyond 60 is ~1e-40)
+        @test WangTransform(0.9)(Poisson(10)) ≈ 14.2936912334644 rtol = 1e-8
+        p10 = Poisson(10)
+        p10dnp = DiscreteNonParametric(collect(0:60), pdf.(p10, 0:60))
+        @test CTE(cdf(p10, 12))(p10) ≈ CTE(cdf(p10, 12))(p10dnp) rtol = 1e-10
+        @test isfinite(CTE(0.9)(Geometric(0.2)))
+    end
+
+    @testset "mean fallback and dispatch" begin
+        # generic truncated wrappers have no `mean` method; Expectation falls
+        # back to checked quadrature
+        tr = truncated(Gamma(2, 3), 1, 5)
+        @test RiskMeasures.Expectation()(tr) ≈ QuadGK.quadgk(x -> x * pdf(tr, x), 1, 5)[1] rtol = 1e-6
+        @test CTE(0.0)(tr) ≈ RiskMeasures.Expectation()(tr)
+        @test VaR(0.9)(tr) <= CTE(0.9)(tr) <= 5
+        # censored distributions have a real `mean` method; it is used directly
+        @test RiskMeasures.Expectation()(censored(Normal(), -1, 1)) == 0.0
+        # an error inside a distribution's own `mean` must propagate
+        @test_throws MethodError RiskMeasures.Expectation()(BrokenMeanDist())
+        # a NaN cdf must surface as an error, not a silent number
+        @test_throws Exception WangTransform(0.9)(NaNCDFRisk())
+        # analytic exactness on distributions
+        @test RiskMeasures.Expectation()(Normal(3, 1)) == 3.0
+        @test VaR(0.95)(LogNormal(0, 1)) == quantile(LogNormal(0, 1), 0.95)
+    end
+
+    @testset "numeric types and accumulation" begin
+        @test RiskMeasures.Expectation()([1e308, 1e308]) == 1e308
+        @test RiskMeasures.Expectation()(fill(typemax(Int), 4)) ≈ 9.223372036854776e18
+        @test RiskMeasures.Expectation()(Float32[1, 2, 3]) ≈ 2
+        @test CTE(0.5)(BigFloat[1, 2, 3, 4]) ≈ big"3.5"
+        for rm in (VaR(0.5), CTE(0.5), RiskMeasures.Expectation(), WangTransform(0.5))
+            @test_throws ArgumentError rm(Float64[])
+        end
+    end
 
 end

--- a/test/risk_measures.jl
+++ b/test/risk_measures.jl
@@ -11,6 +11,15 @@ Distributions.mean(::BrokenMeanDist) = sum(nothing)
 struct NaNCDFRisk end
 ActuaryUtilities.RiskMeasures.cdf_func(::NaNCDFRisk) = x -> NaN
 
+# An integer law with a long zero-mass prefix: all mass sits at 100 but the
+# reported minimum is 0. The checked tail summation must scan past the gap
+# instead of accepting an early all-zero truncation.
+struct DelayedDirac <: DiscreteUnivariateDistribution end
+Distributions.minimum(::DelayedDirac) = 0
+Distributions.maximum(::DelayedDirac) = Inf
+Distributions.cdf(::DelayedDirac, x::Real) = x < 100 ? 0.0 : 1.0
+Distributions.ccdf(::DelayedDirac, x::Real) = x < 100 ? 1.0 : 0.0
+
 @testset "Risk Measures" begin
 
     @test_throws AssertionError VaR(-0.5)
@@ -212,6 +221,15 @@ ActuaryUtilities.RiskMeasures.cdf_func(::NaNCDFRisk) = x -> NaN
         p10dnp = DiscreteNonParametric(collect(0:60), pdf.(p10, 0:60))
         @test CTE(cdf(p10, 12))(p10) ≈ CTE(cdf(p10, 12))(p10dnp) rtol = 1e-10
         @test isfinite(CTE(0.9)(Geometric(0.2)))
+        # zero-mass prefixes must not read as convergence: Poisson(1000) has
+        # ccdf == 1.0 for its first hundreds of atoms (all distorted weights 0),
+        # and DelayedDirac concentrates all mass at 100 with minimum 0
+        p1k = Poisson(1000)
+        p1kdnp = DiscreteNonParametric(collect(600:1400), pdf.(p1k, 600:1400))
+        @test WangTransform(0.9)(p1k) ≈ WangTransform(0.9)(p1kdnp) rtol = 1e-8
+        @test WangTransform(0.9)(DelayedDirac()) ≈ 100.0
+        @test CTE(0.5)(DelayedDirac()) ≈ 100.0
+        @test ProportionalHazard(2)(DelayedDirac()) ≈ 100.0
     end
 
     @testset "mean fallback and dispatch" begin


### PR DESCRIPTION
## Problem

`src/risk_measures.jl` evaluated every distortion risk measure as a Choquet integral built from two unchecked `QuadGK.quadgk` improper integrals, discarded both error estimates, and subtracted them. Divergent integrals came back as believable finite numbers:

```julia
Expectation()(Cauchy())          # 0.0        — the mean does not exist
Expectation()(Pareto(0.5, 1.0))  # 2.9e8      — the true mean is Inf
CTE(0.95)(Cauchy())              # 215.14     — the tail mean is +Inf
```

This can turn an undefined or infinite capital requirement into a plausible finite number.

## Policy

| Situation | Result |
| --- | --- |
| Divergence provable from `mean` semantics (`+Inf`, `NaN`) | honest `Inf` / `NaN` |
| Numerical `NaN`, `-Inf`, or unconverged quadrature | throws `ErrorException` |
| Quadrature `+Inf` without analytic support | throws (unverified) |

## Changes

- **`Expectation`/`VaR`/`CTE` on distributions are analytic or exact.** `Expectation` uses `Distributions.mean` (NaN/±Inf pass through; distributions without a `mean` method, e.g. generic `truncated` wrappers, fall back to checked quadrature). `VaR` is `Distributions.quantile`. `CTE` returns `Inf` exactly when `E[X⁺] = ∞` and otherwise integrates the quantile function — one one-sided integral with an enforced error certificate, no subtraction, no cancellation (`CTE(0.001)(-Pareto(0.5,1))` returns −1000 exactly; the rejected Rockafellar–Uryasev form returned −999.99836).
- **VaR is now the standard lower generalized inverse `inf{x : F(x) ≥ α}` package-wide** (maintainer decision — classified as a bug fix):
  ```julia
  VaR(0.5)(Bernoulli(0.5))       # old: 1, new: 0
  VaR(0.95)(collect(1.0:1000.0)) # old: 951, new: 950
  ```
  `CTE` atom semantics are unchanged (still exactly the worst `1-α` mass with fractional boundary-atom weight). `robustvalue`'s VaR adverse scenario now shifts the rank VaR itself selects; previously, at an exact atom boundary the shifted set could exclude that rank and report zero loading.
- **Exact sums for atomic laws.** Arrays, finite-atom discrete laws (incl. `DiscreteNonParametric`, `Binomial`, `Dirac`), and integer lattice laws bounded below (`Poisson`, `Geometric`) evaluate every distortion as exact or checked sums — survival weights normalized and clamped (even `Binomial`'s pdf sums to 1+7e-16), zero-weight atoms skipped so `Inf·0` cannot poison the result.
- **Checked quadrature for everything else.** Both Choquet components run at `rtol/2`, both certificates are enforced (`isfinite`, nonnegative, within tolerance), and a cancellation-aware final check certifies the subtracted result at the components' scale. Stable distortion algebra (`-expm1(v*log1p(-x))` for `DualPower`, plus stable `gbar` complements) is a correctness requirement here: the naive form's true error exceeded its quadrature certificate by ~200× (`DualPower(2)(Pareto(1.5,1))`: certified 6.7e-8, actual 1.4e-5).
- Docs: corrected Choquet formulation (survival distortion `g` vs complement `ḡ`), evaluation-tier admonition, heavy-tail docstring semantics, and a v5.11.2 upgrade guide with the behavior-change examples.

## Testing

- Full suite green in a clean temp environment (`Pkg.test`), including the entire optimal-transport suite and Aqua.
- New testsets: lower-quantile VaR parity (arrays ≡ atomic ≡ named discrete, exact/ulp boundaries), divergent heavy-tailed risks, stable-distortion certification, atomic robustness (sloppy probability vectors, ±Inf atoms), mean-fallback dispatch (errors inside a real `mean` method propagate), numeric types/overflow-safe accumulation, and `robustvalue` boundary/budget assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)