### PR TITLE
Remove redundant risk measure guards

### DIFF
--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -24,7 +24,6 @@ export wasserstein, transportmap, pushforward, robustvalue
 # of [10,20] for target [10,20]).
 _quantile_fn(d::Distributions.UnivariateDistribution) = u -> Distributions.quantile(d, u)
 function _quantile_fn(x::AbstractVector{<:Real})
-    isempty(x) && throw(ArgumentError("empty sample: a Wasserstein/quantile needs at least one observation"))
     xs = sort(collect(x))
     n = length(xs)
     return u -> xs[clamp(ceil(Int, u * n), 1, n)]
@@ -105,8 +104,6 @@ end
 # W₂([0], [0,2]) is √2, while a size-2 midpoint grid through `Statistics.quantile`
 # gives √1.25.
 function _wasserstein(a::AbstractVector{<:Real}, b::AbstractVector{<:Real}, p; kwargs...)
-    (isempty(a) || isempty(b)) &&
-        throw(ArgumentError("empty sample: wasserstein needs at least one observation in each of `a`, `b`"))
     na, nb = length(a), length(b)
     as, bs = sort(collect(a)), sort(collect(b))
     na == nb && return _pnorm(as .- bs, p)
@@ -270,7 +267,6 @@ end
 # Use midpoint plotting positions instead: the k-th of n order statistics maps to
 # rank (k - 0.5)/n, keeping every transported value finite.
 function transportmap(source::AbstractVector{<:Real}, target)
-    isempty(source) && throw(ArgumentError("empty `source` sample: transportmap needs at least one observation"))
     xs = sort(collect(source))
     n = length(xs)
     Qt = _quantile_fn(target)                  # sorts a sample `target` once, not per call
@@ -356,7 +352,6 @@ function robustvalue(
     radius >= 0 || throw(ArgumentError("radius must be ≥ 0, got $radius"))
     0 <= tail < 1 || throw(ArgumentError("tail must be in [0, 1), got $tail"))
     p >= 1 || throw(ArgumentError("p must be ≥ 1, got $p"))
-    isempty(sample) && throw(ArgumentError("empty `sample`: robustvalue needs at least one observation"))
     # CTE at its own tail level has a closed-form worst case. Its maximizer moves
     # exactly mass 1-α, splitting the atom the tail boundary cuts through — a
     # fractional weight an equally weighted sample cannot represent: any whole-atom

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -109,11 +109,6 @@ julia> rm(rand(1000))
 """
 struct VaR{T <: Real} <: RiskMeasure
     α::T
-
-    function VaR(α::T) where {T}
-        @assert 0 <= α < 1 "α of $α is not 0 ≤ α < 1"
-        return new{T}(α)
-    end
 end
 # The boundary uses `<=` so that the Choquet form of this distortion selects the
 # lower quantile at an atom, matching `Distributions.quantile`.
@@ -171,11 +166,6 @@ julia> rm(rand(1000))
 """
 struct CTE{T <: Real} <: RiskMeasure
     α::T
-
-    function CTE(α::T) where {T}
-        @assert 0 <= α < 1 "α of $α is not 0 ≤ α < 1"
-        return new{T}(α)
-    end
 end
 g(rm::CTE, x) = x < (1 - rm.α) ? x / (1 - rm.α) : 1
 gbar(rm::CTE, F) = F <= rm.α ? zero(F / (1 - rm.α)) : (F - rm.α) / (1 - rm.α)
@@ -221,10 +211,6 @@ julia> rm(rand(1000))
 """
 struct WangTransform{T} <: RiskMeasure
     α::T
-    function WangTransform(α::T) where {T}
-        @assert 0 < α < 1 "α of $α is not 0 < α < 1"
-        return new{T}(α)
-    end
 end
 function g(rm::WangTransform, x)
     Φ_inv(x) = Distributions.quantile(Distributions.Normal(), x)
@@ -326,9 +312,6 @@ _finite_atoms(d::Distributions.DiscreteUnivariateDistribution) =
     d isa Distributions.DiscreteNonParametric || Distributions.hasfinitesupport(d)
 
 function _choquet(rm::RiskMeasure, risk; rtol = sqrt(eps(Float64)), atol = 0.0, maxevals = 10^7)
-    (isfinite(rtol) && rtol >= 0) || throw(ArgumentError("rtol must be finite and nonnegative"))
-    (isfinite(atol) && atol >= 0) || throw(ArgumentError("atol must be finite and nonnegative"))
-    maxevals > 0 || throw(ArgumentError("maxevals must be positive"))
     G = ccdf_func(risk)   # hoisted: each closure is built once, not once per node
     F = cdf_func(risk)
     # Each side runs at half the requested tolerance. The two certificates then
@@ -491,7 +474,6 @@ end
 # ProportionalHazard, user-defined). The VaR/CTE/Expectation methods below are
 # more specific and intercept first.
 function (rm::RiskMeasure)(risk::AbstractArray{<:Real})
-    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
     xs = sort(vec(risk))
     n = length(xs)
     T = float(eltype(xs))
@@ -502,7 +484,6 @@ function (rm::RiskMeasure)(risk::AbstractArray{<:Real})
 end
 
 function (rm::VaR)(risk::AbstractArray{<:Real})
-    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
     n = length(risk)
     k = _first_index_at_or_above(n, rm.α)
     return partialsort(vec(risk), k)
@@ -514,7 +495,6 @@ end
 # Elements are divided by n before summing so that large samples cannot
 # overflow the accumulator.
 function (rm::CTE)(risk::AbstractArray{<:Real})
-    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
     n = length(risk)
     α = rm.α
     k = _first_index_above(n, α)
@@ -526,7 +506,6 @@ function (rm::CTE)(risk::AbstractArray{<:Real})
 end
 
 function (rm::Expectation)(risk::AbstractArray{<:Real})
-    isempty(risk) && throw(ArgumentError("the risk sample must contain at least one outcome"))
     n = length(risk)
     return sum(x -> x / n, risk)
 end

--- a/test/optimal_transport.jl
+++ b/test/optimal_transport.jl
@@ -32,9 +32,6 @@
         @test wasserstein([10, 20], [1, 2, 3, 4, 5]) ≈ 12.0   # symmetric
 
         @test_throws ArgumentError wasserstein([1, 2], [3, 4]; p = 0.5)
-        # empty samples fail loudly rather than returning NaN
-        @test_throws ArgumentError wasserstein(Float64[], [1.0, 2.0])
-        @test_throws ArgumentError wasserstein([1.0, 2.0], Float64[])
 
         # Distribution forms use adaptive quantile integration and distinguish a
         # genuinely divergent moment from tail cancellation between two laws.
@@ -181,7 +178,6 @@
         @test robustvalue(WangTransform(0.95), sw; radius = 100, tail = 0.95) > WangTransform(0.95)(sw)
         @test_throws ArgumentError robustvalue(WangTransform(0.95), s; radius = 100)
         @test_throws ArgumentError robustvalue(CTE(0.95), s; radius = -1)
-        @test_throws ArgumentError robustvalue(CTE(0.95), Float64[]; radius = 100)
     end
 
 end

--- a/test/risk_measures.jl
+++ b/test/risk_measures.jl
@@ -22,14 +22,6 @@ Distributions.ccdf(::DelayedDirac, x::Real) = x < 100 ? 1.0 : 0.0
 
 @testset "Risk Measures" begin
 
-    @test_throws AssertionError VaR(-0.5)
-    @test_throws AssertionError VaR(1.0)
-    @test_throws AssertionError VaR(1.5)
-    @test_throws AssertionError CTE(-0.5)
-    @test_throws AssertionError CTE(1.0)
-    @test_throws AssertionError CTE(1.5)
-    @test_throws AssertionError WangTransform(0.0)
-    @test_throws AssertionError WangTransform(1.0)
     for bad in (0, -1, Inf, NaN)
         @test_throws ArgumentError DualPower(bad)
         @test_throws ArgumentError ProportionalHazard(bad)
@@ -259,9 +251,6 @@ Distributions.ccdf(::DelayedDirac, x::Real) = x < 100 ? 1.0 : 0.0
         @test RiskMeasures.Expectation()(fill(typemax(Int), 4)) ≈ 9.223372036854776e18
         @test RiskMeasures.Expectation()(Float32[1, 2, 3]) ≈ 2
         @test CTE(0.5)(BigFloat[1, 2, 3, 4]) ≈ big"3.5"
-        for rm in (VaR(0.5), CTE(0.5), RiskMeasures.Expectation(), WangTransform(0.5))
-            @test_throws ArgumentError rm(Float64[])
-        end
     end
 
 end


### PR DESCRIPTION
Removes guards that conflict with the house style: constructor assertions in `VaR`, `CTE`, and `WangTransform`, unreachable tolerance validation in `_choquet`, and pre-emptive empty-sample throws in risk measures and optimal transport. Removes the tests requiring those explicit errors and uses default constructors where the assertions were the only custom logic.

KeyRates invariants and length checks protecting `@inbounds` code remain intact.

Validation: all 232 risk-measure and optimal-transport tests passed with precompilation disabled; `git diff --check` passed. The full suite could not start because the local FinanceModels checkout fails to precompile against the installed DataInterpolations version.
