### PR TITLE
Compute exact transport for finite atomic measures

### DIFF
--- a/src/ActuaryUtilities.jl
+++ b/src/ActuaryUtilities.jl
@@ -18,6 +18,7 @@ import Distributions
 function duration end
 
 include("financial_math.jl")
+include("atomic_measures.jl")
 include("risk_measures.jl")
 include("optimal_transport.jl")
 include("utilities.jl")

--- a/src/atomic_measures.jl
+++ b/src/atomic_measures.jl
@@ -1,0 +1,42 @@
+module AtomicMeasures
+
+import ..Distributions
+
+# Shared sorted, normalized atoms for exact risk and transport calculations.
+struct FiniteAtoms{X, P}
+    values::X
+    probabilities::P
+    function FiniteAtoms(xs, ps)
+        length(xs) == length(ps) || throw(DimensionMismatch("atoms and probabilities must have equal length"))
+        all(p -> isfinite(p) && p >= 0, ps) || throw(ArgumentError("atom probabilities must be finite and nonnegative"))
+        total = sum(ps)
+        (isfinite(total) && total > 0) || throw(ArgumentError("atom probabilities must have a positive finite sum, got $total"))
+        order = sortperm(xs)
+        filter!(i -> !iszero(ps[i]), order)
+        values = xs[order]
+        probabilities = ps[order] ./ total
+        return new{typeof(values), typeof(probabilities)}(values, probabilities)
+    end
+end
+
+finite_atoms(d) = nothing
+function finite_atoms(d::Distributions.DiscreteUnivariateDistribution)
+    # Atom count can be finite even when the support contains infinity.
+    (d isa Union{Distributions.DiscreteNonParametric, Distributions.Dirac} || Distributions.hasfinitesupport(d)) || return nothing
+    xs = collect(Distributions.support(d))
+    return FiniteAtoms(xs, Distributions.pdf.(d, xs))
+end
+function finite_atoms(xs::AbstractVector{<:Real})
+    isempty(xs) && throw(ArgumentError("an empirical measure needs at least one observation"))
+    # Rational ranks preserve exact i/n breakpoints, even for unequal samples.
+    return FiniteAtoms(collect(xs), fill(1 // length(xs), length(xs)))
+end
+
+function probability_breaks(atoms::FiniteAtoms)
+    breaks = cumsum(atoms.probabilities)
+    clamp!(breaks, zero(eltype(breaks)), one(eltype(breaks)))
+    breaks[end] = one(eltype(breaks))
+    return breaks
+end
+
+end

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -67,10 +67,14 @@ julia> wasserstein(Normal(0, 1), Normal(0, 2); p=2) # same mean, |σ₁-σ₂|
 
 See also [`transportmap`](@ref), [`robustvalue`](@ref).
 
-Finite discrete laws and empirical samples share an exact cumulative-mass sweep,
-including `p=Inf`. For a finite atomic law against a continuous distribution,
-`p=Inf` uses the limits of each atomic quantile interval. Other distribution pairs
-use numerical quantile integration or supremum search.
+Finite discrete laws and empirical samples use exact cumulative-mass sweeps,
+including `p=Inf`; sample pairs use integer ranks without constructing atom weights.
+For a finite atomic law against a continuous distribution, `p=Inf` uses the limits
+of each atomic quantile interval. Interior right limits are approximated by
+evaluating the quantile at the next representable probability above the break;
+accuracy there depends on floating-point resolution and the distribution's quantile
+implementation. Other distribution pairs use numerical quantile integration or
+supremum search.
 `rtol`, `atol`, and `maxevals` control that calculation. By default the
 evaluation budget scales with the number of empirical quantile segments; an
 explicit `maxevals` is a hard cap for the numerical calculation. Finite-`p`
@@ -94,12 +98,54 @@ function wasserstein(
     (isfinite(rtol) && rtol >= 0) || throw(ArgumentError("rtol must be finite and nonnegative"))
     (isfinite(atol) && atol >= 0) || throw(ArgumentError("atol must be finite and nonnegative"))
     (isnothing(maxevals) || maxevals > 0) || throw(ArgumentError("maxevals must be positive"))
+    if a isa AbstractVector{<:Real} && b isa AbstractVector{<:Real}
+        return _wasserstein(a, b, p)
+    end
     aa, bb = finite_atoms(a), finite_atoms(b)
     return _wasserstein(isnothing(aa) ? a : aa, isnothing(bb) ? b : bb, p; rtol, atol, maxevals)
 end
 
+# Sample pairs need only sorted values. Integer ranks on a common denominator
+# preserve every overlap without allocating rational weights or cumulative sums.
+function _wasserstein(a::AbstractVector{<:Real}, b::AbstractVector{<:Real}, p; kwargs...)
+    (isempty(a) || isempty(b)) &&
+        throw(ArgumentError("an empirical measure needs at least one observation"))
+    as, bs = sort!(collect(a)), sort!(collect(b))
+    na, nb = length(as), length(bs)
+    if na == nb
+        acc = zero(float(promote_type(eltype(as), eltype(bs), Float64)))
+        for i in eachindex(as, bs)
+            gap = as[i] == bs[i] ? zero(acc) : typeof(acc)(abs(as[i] - bs[i]))
+            acc = isinf(p) ? max(acc, gap) : acc + gap^p
+        end
+        return isinf(p) ? acc : (acc / na)^(1 / p)
+    end
+    # Widen the product before deciding whether machine-integer ranks suffice.
+    # The helper specializes on the rank type, keeping the usual loop in Int.
+    denominator = widemul(na, nb)
+    return _wasserstein_samples(as, bs, p, denominator <= typemax(Int) ? Int(denominator) : denominator)
+end
+
+function _wasserstein_samples(as, bs, p, denominator)
+    na, nb = length(as), length(bs)
+    step_a, step_b = oftype(denominator, nb), oftype(denominator, na)
+    i = j = 1
+    prev = zero(denominator)
+    acc = zero(float(promote_type(eltype(as), eltype(bs), Float64)))
+    while i <= na && j <= nb
+        ua, ub = i * step_a, j * step_b
+        u = min(ua, ub)
+        gap = as[i] == bs[j] ? zero(acc) : typeof(acc)(abs(as[i] - bs[j]))
+        acc = isinf(p) ? max(acc, gap) : acc + (typeof(acc)(u - prev) / denominator) * gap^p
+        prev = u
+        ua <= ub && (i += 1)
+        ub <= ua && (j += 1)
+    end
+    return isinf(p) ? acc : acc^(1 / p)
+end
+
 # Merge cumulative probability boundaries: each overlap contributes its exact
-# mass times the quantile gap. The same sweep covers samples and discrete laws.
+# mass times the quantile gap. Sample/distribution pairs also use this sweep.
 function _wasserstein(a::FiniteAtoms, b::FiniteAtoms, p; kwargs...)
     as, bs = a.values, b.values
     ac, bc = probability_breaks(a), probability_breaks(b)
@@ -113,7 +159,7 @@ function _wasserstein(a::FiniteAtoms, b::FiniteAtoms, p; kwargs...)
         advance_b = bc[j] <= ac[i]
         u = advance_a ? ac[i] : bc[j]
         if u > prev
-            gap = as[i] == bs[j] ? zero(acc) : abs(as[i] - bs[j])
+            gap = as[i] == bs[j] ? zero(acc) : typeof(acc)(abs(as[i] - bs[j]))
             acc = isinf(p) ? max(acc, gap) : acc + (u - prev) * gap^p
         end
         prev = u
@@ -177,7 +223,12 @@ function _wasserstein_infinity(a::FiniteAtoms, b::Distributions.ContinuousUnivar
     acc = zero(float(promote_type(eltype(a.values), eltype(a.probabilities))))
     for (x, u) in zip(a.values, probability_breaks(a))
         if u > previous
-            acc = max(acc, abs(x - Distributions.quantile(b, previous)), abs(x - Distributions.quantile(b, u)))
+            # The interval is (previous, u]: at a support gap Q(previous)
+            # belongs to the preceding interval, so approach from the right.
+            lower_rank = iszero(previous) ? float(previous) : min(nextfloat(float(previous)), one(float(previous)))
+            lower = Distributions.quantile(b, lower_rank)
+            upper = Distributions.quantile(b, u)
+            acc = max(acc, abs(x - lower), abs(x - upper))
         end
         previous = u
     end

--- a/src/optimal_transport.jl
+++ b/src/optimal_transport.jl
@@ -5,7 +5,7 @@ import ..StatsBase
 import ..RiskMeasures
 import ..RiskMeasures: RiskMeasure, CTE, VaR
 import ..QuadGK
-import Statistics
+import ..AtomicMeasures: FiniteAtoms, finite_atoms, probability_breaks
 
 export wasserstein, transportmap, pushforward, robustvalue
 
@@ -28,9 +28,6 @@ function _quantile_fn(x::AbstractVector{<:Real})
     n = length(xs)
     return u -> xs[clamp(ceil(Int, u * n), 1, n)]
 end
-
-_pnorm(diffs, p) = isinf(p) ? maximum(abs, diffs) :
-    (Statistics.mean(abs.(diffs) .^ p))^(1 / p)
 
 """
     wasserstein(a, b; p=1, rtol=1e-6, atol=0, maxevals=nothing)
@@ -70,13 +67,16 @@ julia> wasserstein(Normal(0, 1), Normal(0, 2); p=2) # same mean, |σ₁-σ₂|
 
 See also [`transportmap`](@ref), [`robustvalue`](@ref).
 
-For risks involving a distribution, the quantile integral is evaluated adaptively.
+Finite discrete laws and empirical samples share an exact cumulative-mass sweep,
+including `p=Inf`. For a finite atomic law against a continuous distribution,
+`p=Inf` uses the limits of each atomic quantile interval. Other distribution pairs
+use numerical quantile integration or supremum search.
 `rtol`, `atol`, and `maxevals` control that calculation. By default the
 evaluation budget scales with the number of empirical quantile segments; an
-explicit `maxevals` is a hard cap. If the requested tolerance cannot be verified,
-`wasserstein` throws rather than returning an unconverged approximation.
-For distributional `p=Inf`, this includes empirical-versus-bounded-distribution
-cases whose supremum is not certified within the evaluation budget. Infinite
+explicit `maxevals` is a hard cap for the numerical calculation. Finite-`p`
+quadrature throws if its error estimate exceeds the requested tolerance.
+For general distributional `p=Inf`, stable grid maxima are a numerical
+approximation, not a supremum certificate. Infinite
 distance is returned only when proved by support bounds or a supported analytic
 family; unresolved same-side-unbounded pairs throw rather than relying on tail
 growth heuristics.
@@ -94,29 +94,31 @@ function wasserstein(
     (isfinite(rtol) && rtol >= 0) || throw(ArgumentError("rtol must be finite and nonnegative"))
     (isfinite(atol) && atol >= 0) || throw(ArgumentError("atol must be finite and nonnegative"))
     (isnothing(maxevals) || maxevals > 0) || throw(ArgumentError("maxevals must be positive"))
-    return _wasserstein(a, b, p; rtol, atol, maxevals)
+    aa, bb = finite_atoms(a), finite_atoms(b)
+    return _wasserstein(isnothing(aa) ? a : aa, isnothing(bb) ? b : bb, p; rtol, atol, maxevals)
 end
 
-# both samples: exact in both cases. Equal sizes reduce to sorted point-by-point
-# matching; unequal sizes integrate |Qa - Qb|^p exactly by merging the breakpoints
-# {i/na} ∪ {j/nb} of the two inverse-ECDF step functions. A fixed evaluation grid
-# (or an interpolated quantile) computes a different number — e.g. the true
-# W₂([0], [0,2]) is √2, while a size-2 midpoint grid through `Statistics.quantile`
-# gives √1.25.
-function _wasserstein(a::AbstractVector{<:Real}, b::AbstractVector{<:Real}, p; kwargs...)
-    na, nb = length(a), length(b)
-    as, bs = sort(collect(a)), sort(collect(b))
-    na == nb && return _pnorm(as .- bs, p)
+# Merge cumulative probability boundaries: each overlap contributes its exact
+# mass times the quantile gap. The same sweep covers samples and discrete laws.
+function _wasserstein(a::FiniteAtoms, b::FiniteAtoms, p; kwargs...)
+    as, bs = a.values, b.values
+    ac, bc = probability_breaks(a), probability_breaks(b)
     i = j = 1
-    prev = 0.0
-    acc = 0.0
-    while i <= na && j <= nb
-        u = min(i / na, j / nb)
-        gap = abs(as[i] - bs[j])
-        acc = isinf(p) ? max(acc, gap) : acc + (u - prev) * gap^p
+    prev = zero(promote_type(eltype(ac), eltype(bc)))
+    acc = zero(float(promote_type(eltype(as), eltype(bs), typeof(prev))))
+    while i <= length(as) && j <= length(bs)
+        # Decide which indices advance before combining numeric types: `min`
+        # can round a rational rank down when paired with a floating mass.
+        advance_a = ac[i] <= bc[j]
+        advance_b = bc[j] <= ac[i]
+        u = advance_a ? ac[i] : bc[j]
+        if u > prev
+            gap = as[i] == bs[j] ? zero(acc) : abs(as[i] - bs[j])
+            acc = isinf(p) ? max(acc, gap) : acc + (u - prev) * gap^p
+        end
         prev = u
-        i / na <= u && (i += 1)
-        j / nb <= u && (j += 1)
+        advance_a && (i += 1)
+        advance_b && (j += 1)
     end
     return isinf(p) ? acc : acc^(1 / p)
 end
@@ -136,7 +138,11 @@ function _divergent_quantile_tail(f)
 end
 
 _quantile_breaks(::Distributions.UnivariateDistribution) = Float64[]
-_quantile_breaks(x::AbstractVector) = collect((1:(length(x) - 1)) ./ length(x))
+_quantile_breaks(a::FiniteAtoms) = probability_breaks(a)[1:(end - 1)]
+function _quantile_fn(a::FiniteAtoms)
+    breaks = probability_breaks(a)
+    return u -> a.values[clamp(searchsortedfirst(breaks, u), 1, length(breaks))]
+end
 
 function _wasserstein_finite(a, b, p; rtol, atol, maxevals)
     Qa, Qb = _quantile_fn(a), _quantile_fn(b)
@@ -162,7 +168,23 @@ end
 # doubling, so their maxima are monotone lower bounds. A finite answer is returned
 # only after several refinements agree; unresolved tails fail loudly.
 _support_bounds(d::Distributions.UnivariateDistribution) = (minimum(d), maximum(d))
-_support_bounds(x::AbstractVector) = extrema(x)
+_support_bounds(a::FiniteAtoms) = (first(a.values), last(a.values))
+
+# On each atomic quantile interval the continuous quantile is monotone, so
+# the largest gap to the constant atom occurs at one of the interval limits.
+function _wasserstein_infinity(a::FiniteAtoms, b::Distributions.ContinuousUnivariateDistribution; kwargs...)
+    previous = zero(eltype(a.probabilities))
+    acc = zero(float(promote_type(eltype(a.values), eltype(a.probabilities))))
+    for (x, u) in zip(a.values, probability_breaks(a))
+        if u > previous
+            acc = max(acc, abs(x - Distributions.quantile(b, previous)), abs(x - Distributions.quantile(b, u)))
+        end
+        previous = u
+    end
+    return acc
+end
+_wasserstein_infinity(a::Distributions.ContinuousUnivariateDistribution, b::FiniteAtoms; kwargs...) =
+    _wasserstein_infinity(b, a; kwargs...)
 
 function _support_proves_infinite(a, b)
     alo, ahi = _support_bounds(a)
@@ -216,7 +238,7 @@ function _wasserstein_infinity(a, b; rtol, atol, maxevals)
     throw(ErrorException("wasserstein W∞ supremum search did not converge within maxevals=$budget"))
 end
 
-# At least one argument is a distribution: use verified adaptive computation.
+# At least one argument lacks a finite atom representation.
 function _wasserstein(a, b, p; rtol, atol, maxevals)
     return isinf(p) ? _wasserstein_infinity(a, b; rtol, atol, maxevals) :
         _wasserstein_finite(a, b, p; rtol, atol, maxevals)

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -1,4 +1,5 @@
 module RiskMeasures
+import ..AtomicMeasures: finite_atoms, FiniteAtoms
 import ..Distributions
 import ..StatsBase
 import ..QuadGK
@@ -298,18 +299,13 @@ gbar(rm::ProportionalHazard, F) = -expm1(log1p(-F) / rm.y)
 # returning a silently wrong number.
 function (rm::RiskMeasure)(risk)
     if risk isa Distributions.DiscreteUnivariateDistribution
-        _finite_atoms(risk) && return _distorted_sum(rm, _atoms(risk)...)
+        atoms = finite_atoms(risk)
+        isnothing(atoms) || return _distorted_sum(rm, atoms)
         lo = minimum(risk)
         (eltype(risk) <: Integer && isfinite(lo)) && return _distorted_tail_sum(rm, risk, lo)
     end
     return _choquet(rm, risk)
 end
-
-# `hasfinitesupport` reports whether the support VALUES are bounded, so it is
-# false for a DiscreteNonParametric with an atom at ±Inf even though the atom
-# COUNT is finite. The exact sum only needs finitely many atoms.
-_finite_atoms(d::Distributions.DiscreteUnivariateDistribution) =
-    d isa Distributions.DiscreteNonParametric || Distributions.hasfinitesupport(d)
 
 function _choquet(rm::RiskMeasure, risk; rtol = sqrt(eps(Float64)), atol = 0.0, maxevals = 10^7)
     G = ccdf_func(risk)   # hoisted: each closure is built once, not once per node
@@ -359,14 +355,9 @@ end
 #
 # No quadrature crosses the cdf's jump discontinuities, so the sum is exact.
 
-function _atoms(d::Distributions.DiscreteUnivariateDistribution)
-    xs = collect(Distributions.support(d))   # sorted; `collect` also handles Dirac's tuple
-    return xs, Distributions.pdf.(d, xs)
-end
-
-function _distorted_sum(rm::RiskMeasure, xs, ps)
+function _distorted_sum(rm::RiskMeasure, atoms::FiniteAtoms)
+    xs, ps = atoms.values, atoms.probabilities
     total = sum(ps)
-    (isfinite(total) && total > 0) || throw(ArgumentError("atom probabilities must have a positive finite sum, got $total"))
     n = length(xs)
     T = float(promote_type(eltype(xs), eltype(ps)))
     # Survival values are normalized by the actual total and clamped into
@@ -520,11 +511,12 @@ _mean_available(d) =
     which(Distributions.mean, Tuple{typeof(d)}) !== which(Distributions.mean, Tuple{Any})
 
 function (rm::Expectation)(risk::Distributions.UnivariateDistribution)
-    if risk isa Distributions.DiscreteUnivariateDistribution && _finite_atoms(risk)
+    atoms = finite_atoms(risk)
+    if !isnothing(atoms)
         # exact weighted sum; the identity distortion makes this Σ xᵢpᵢ with
         # zero-probability atoms skipped (an Inf atom with p = 0 must not
         # produce NaN, as `mean` would)
-        return _distorted_sum(rm, _atoms(risk)...)
+        return _distorted_sum(rm, atoms)
     end
     _mean_available(risk) && return Distributions.mean(risk)   # NaN / ±Inf pass through
     return _choquet(rm, risk)   # e.g. truncated wrappers without a `mean` method
@@ -536,8 +528,9 @@ end
 
 function (rm::CTE)(risk::Distributions.UnivariateDistribution)
     α = rm.α
-    if risk isa Distributions.DiscreteUnivariateDistribution && _finite_atoms(risk)
-        return _distorted_sum(rm, _atoms(risk)...)   # exact fractional-atom tail sum
+    atoms = finite_atoms(risk)
+    if !isnothing(atoms)
+        return _distorted_sum(rm, atoms)   # exact fractional-atom tail sum
     end
     m = _mean_available(risk) ? Distributions.mean(risk) : nothing
     if iszero(α)

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -357,14 +357,12 @@ end
 
 function _distorted_sum(rm::RiskMeasure, atoms::FiniteAtoms)
     xs, ps = atoms.values, atoms.probabilities
-    total = sum(ps)
     n = length(xs)
     T = float(promote_type(eltype(xs), eltype(ps)))
-    # Survival values are normalized by the actual total and clamped into
-    # [0, 1]: even a pristine Binomial pdf sums to 1 + 7e-16, which would push
-    # a reverse cumsum above 1 and break distortions such as Φ⁻¹.
+    # FiniteAtoms normalizes the probabilities. Clamp accumulated roundoff into
+    # [0, 1] so it cannot break distortions such as Φ⁻¹.
     tailp = reverse!(cumsum(reverse(ps)))
-    S(i) = i == 1 ? one(T) : i > n ? zero(T) : clamp(T(tailp[i]) / total, zero(T), one(T))
+    S(i) = i == 1 ? one(T) : i > n ? zero(T) : clamp(T(tailp[i]), zero(T), one(T))
     return sum(eachindex(xs)) do i
         w = g(rm, S(i)) - g(rm, S(i + 1))
         # Skip zero weights before multiplying: an atom at ±Inf with zero

--- a/test/discrete_transport.jl
+++ b/test/discrete_transport.jl
@@ -31,6 +31,45 @@
     @test wasserstein(Uniform(), atomic; p = Inf) == 0.8
     @test wasserstein(atomic, Normal(); p = Inf) == Inf
 
+    # A flat cdf gives a quantile jump at the atomic break. The second interval
+    # starts at Q(0.5+) = 2, not Q(0.5) = 1, so its largest gap is 10 - 2.
+    mix = MixtureModel([Uniform(0, 1), Uniform(2, 3)])
+    gapped = DiscreteNonParametric([0.0, 10.0], [0.5, 0.5])
+    @test wasserstein(gapped, mix; p = Inf, maxevals = 1) ≈ 8.0
+    @test wasserstein(mix, gapped; p = Inf) ≈ 8.0
+    @test wasserstein([0.0, 10.0], mix; p = Inf) ≈ 8.0
+    # The upper endpoint still uses the left limit of the break.
+    @test wasserstein(DiscreteNonParametric([-10.0, 3.0], [0.5, 0.5]), mix; p = Inf) ≈ 11.0
+    inactive_support = MixtureModel([Uniform(-100, -99), Uniform(0, 1), Uniform(99, 100)], [0.0, 1.0, 0.0])
+    @test wasserstein(Dirac(0.0), inactive_support; p = Inf) ≈ 1.0
+
+    # Integer support must be promoted before exponentiation. Check both sample
+    # paths, weighted laws, and a Binomial against its analytic fourth moment.
+    for target in ([0, 0], [0, 0, 0], Dirac(0))
+        @test wasserstein([0, 10^7], target; p = 3) ≈ 10^7 / cbrt(2)
+    end
+    @test wasserstein(DiscreteNonParametric([0, 10^7], [0.5, 0.5]), Dirac(0); p = 3) ≈ 10^7 / cbrt(2)
+    n = 10^6
+    fourth_moment = (Float64(n)^4 + 6 * Float64(n)^3 + 3 * Float64(n)^2 - 2 * n) / 16
+    @test wasserstein(Binomial(n, 0.5), Dirac(0); p = 4) ≈ fourth_moment^(1 / 4)
+
+    # Compare integer-rank sample sweeps with independent rank expansion onto
+    # an LCM grid, including shared breaks, coprime sizes, and repeated values.
+    rng = MersenneTwister(159)
+    for (na, nb) in ((1, 1), (6, 6), (6, 4), (7, 11)), p in (1, 2, 3, Inf)
+        sa, sb = rand(rng, -4:4, na), rand(rng, -4:4, nb)
+        count = lcm(na, nb)
+        gaps = abs.(repeat(sort(sa); inner = count ÷ na) .- repeat(sort(sb); inner = count ÷ nb))
+        expected = isinf(p) ? maximum(gaps) : (sum(gaps .^ p) / count)^(1 / p)
+        @test wasserstein(sa, sb; p, maxevals = 1) ≈ expected
+        @test wasserstein(sb, sa; p) ≈ expected
+    end
+    @test_throws ArgumentError wasserstein(Float64[], [0.0])
+    @test_throws ArgumentError wasserstein([0.0], Float64[])
+    @test wasserstein([Inf], [Inf]) == 0
+    @test wasserstein([Inf], [Inf, Inf]; p = Inf) == 0
+    @test wasserstein(BigFloat[0, 1, 2], BigFloat[0, 0]) ≈ big"1.0" rtol = big"1e-60"
+
     # Zero-mass extreme atoms do not contribute a gap or an infinite cost.
     zero_atom = DiscreteNonParametric([0.0, 1.0, Inf], [0.5, 0.5, 0.0])
     @test wasserstein(zero_atom, [0.0, 1.0]; p = Inf) == 0

--- a/test/discrete_transport.jl
+++ b/test/discrete_transport.jl
@@ -1,0 +1,44 @@
+@testset "Exact finite discrete transport" begin
+    a = DiscreteNonParametric([0, 1, 2], [0.5, 0.00001, 0.49999])
+    b = DiscreteNonParametric([0, 2], [0.50001, 0.49999])
+    for p in (1, 2, 3, Inf)
+        expected = isinf(p) ? 1.0 : 0.00001^(1 / p)
+        @test wasserstein(a, b; p, maxevals = 1) ≈ expected rtol = 1.0e-10
+        @test wasserstein(b, a; p) ≈ expected rtol = 1.0e-10
+    end
+
+    # Repeated empirical outcomes and finite laws represent the same measure.
+    sample = [2, 0, 1, 2, 0, 2]
+    law = DiscreteNonParametric([0, 1, 2], [2 // 6, 1 // 6, 3 // 6])
+    target = [-1, 0, 3, 5]
+    target_law = DiscreteNonParametric(target, fill(0.25, 4))
+    for p in (1, 2, 3, Inf)
+        reference = wasserstein(sample, target; p)
+        @test wasserstein(law, target; p) ≈ reference
+        @test wasserstein(sample, target_law; p) ≈ reference
+        @test wasserstein(law, target_law; p) ≈ reference
+        @test wasserstein(sample, law; p) ≈ 0 atol = 1.0e-14
+        @test wasserstein(Binomial(3, 0.5), Dirac(0); p) ≈
+            (isinf(p) ? 3.0 : sum(k^p * pdf(Binomial(3, 0.5), k) for k in 0:3)^(1 / p))
+    end
+
+    # Against Uniform(0,1), integrate |x-u| separately over each atom's rank
+    # interval; the supremum occurs at an interval endpoint (one-sided limits).
+    atomic = DiscreteNonParametric([0.0, 1.0], [0.8, 0.2])
+    @test wasserstein(atomic, Uniform()) ≈ (0.8^2 + 0.2^2) / 2
+    @test wasserstein(atomic, Uniform(); p = 2) ≈ sqrt((0.8^3 + 0.2^3) / 3)
+    @test wasserstein(atomic, Uniform(); p = Inf, maxevals = 1) == 0.8
+    @test wasserstein(Uniform(), atomic; p = Inf) == 0.8
+    @test wasserstein(atomic, Normal(); p = Inf) == Inf
+
+    # Zero-mass extreme atoms do not contribute a gap or an infinite cost.
+    zero_atom = DiscreteNonParametric([0.0, 1.0, Inf], [0.5, 0.5, 0.0])
+    @test wasserstein(zero_atom, [0.0, 1.0]; p = Inf) == 0
+    @test wasserstein(Dirac(Inf), Dirac(Inf)) == 0
+    @test wasserstein(Dirac(Inf), Dirac(0.0)) == Inf
+    @test Expectation()(zero_atom) ≈ 0.5
+    @test CTE(0.5)(zero_atom) ≈ 1.0
+    for rm in (Expectation(), CTE(0.6), WangTransform(0.3), DualPower(2))
+        @test rm(law) ≈ rm(sample)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ const FC = ActuaryUtilities.FinanceCore
 
 include("risk_measures.jl")
 include("optimal_transport.jl")
+include("discrete_transport.jl")
 include("audit.jl")
 
 @testset "Temporal functions" begin


### PR DESCRIPTION
Finite discrete distributions currently use quantile quadrature or sampled supremum search, missing narrow probability intervals. For `DiscreteNonParametric([0,1,2], [0.5,0.00001,0.49999])` against `DiscreteNonParametric([0,2], [0.50001,0.49999])`, both W1 and W-infinity incorrectly return zero; the exact values are 0.00001 and 1.

Share sorted, normalized finite atoms between risk measures and transport, and integrate weighted atomic laws with a cumulative-mass sweep. Sample pairs retain sorted point-by-point matching for equal sizes and sweep integer ranks on a common denominator for unequal sizes, avoiding rational weights and cumulative arrays on the large-sample path. Sample/distribution pairs retain rational empirical ranks, with independent advancement across mixed probability types. Gaps are converted to the floating accumulator type before exponentiation so large integer supports do not overflow in `gap^p`.

Known atomic jumps become quadrature boundaries for mixed inputs. Atomic-versus-continuous W-infinity evaluates each interval's endpoint limits; at interior lower endpoints it approximates the right limit with the next representable probability, handling continuous laws with support gaps. The docstring states the floating-point and quantile-implementation limits of that approximation. General distribution-versus-distribution supremum search remains numerical.

Validation:

- Full AU suite passes on Julia 1.12.5: 944 assertions, including risk measures and Aqua.
- All 89 focused discrete-transport assertions pass on Julia 1.10.10 and 1.12.5. Regressions cover the narrow-mass counterexample, equal/unequal sample ranks against an independent LCM-grid reference, large integer samples and finite laws, the analytic Binomial fourth moment, disconnected continuous support, zero-weight mixture components, and BigFloat rank precision.
- Exact atomic paths succeed with `maxevals=1`; numerical paths retain convergence checks.
- Runic checks for `src` and `test`, and `git diff --check`, pass.

Sample performance on Julia 1.12.5, using seeded normal samples, one warmup and five measured calls (median time; minimum allocated bytes). The baseline is this PR's base commit, `327e62f`, loaded with the same dependencies. Equal cases use two one-million-element samples; the unequal case uses 1,000,000 and 1,000,001 elements.

| Case | Base | Revised PR | Base allocation | Revised allocation |
| --- | ---: | ---: | ---: | ---: |
| Equal W1 | 19.3 ms | 18.9 ms | 61.3 MiB | 32.6 MiB |
| Equal W2 | 19.9 ms | 19.0 ms | 63.1 MiB | 28.8 MiB |
| Unequal W1 | 31.0 ms | 20.8 ms | 49.8 MiB | 36.4 MiB |
| Equal W-infinity | 17.9 ms | 17.5 ms | 51.7 MiB | 28.8 MiB |

Addresses AU review finding #4. Independent branch against `master`.
