### PR TITLE
Delegate contract projection requirements to FinanceModels

### DIFF
--- a/src/financial_math.jl
+++ b/src/financial_math.jl
@@ -1399,28 +1399,28 @@ sensitivities(vf::Function, ::DV01, kr::KeyRates, base::AYM, credit::AYM) = sens
 #
 # A contract (or a vector of contracts = a portfolio) is a "target": it is valued
 # by RE-PROJECTING under a bumped curve, so a floater's coupons re-fix automatically
-# (its projection reads the model) while a fixed bond's do not. `_contract_keys`
-# (empty vs not) is the only discriminator — no `ValuationStyle` trait. The risk
+# (its projection reads the model) while a fixed bond's do not. FinanceModels
+# owns model requirements and projection of contract wrappers. The risk
 # factor stays the familiar vocabulary: `Effective` (rate) / `Spread` (credit) /
 # `KeyRates`; units are the verb (`duration` yrs / `dv01` $ / `convexity`).
-
-_contract_keys(c::FinanceModels.Bond.Floating) = (c.key,)
-_contract_keys(c::FinanceCore.Composite) = (_contract_keys(c.a)..., _contract_keys(c.b)...)
-_contract_keys(c::FinanceModels.Forward) = _contract_keys(c.instrument)
-_contract_keys(::FinanceCore.AbstractContract) = ()
 
 const _Contractish = Union{FinanceCore.AbstractContract, AbstractVector{<:FinanceCore.AbstractContract}}
 
 """
-    reproject(contract, index_curve)
+    reproject(contract, index_curve::AbstractYieldModel)
+    reproject(contract, models)
 
-Wrap `contract` so its coupons are estimated off `index_curve`: returns the contract
-itself if it reads no model, else a `Projection` mapping the contract's keys to
-`index_curve`. Lets a multi-curve valuation avoid hand-writing the model `Dict`.
+Return a `FinanceModels.Projection` with the models needed by `contract`.
+The single-index convenience delegates model requirements and wrapper traversal
+entirely to FinanceModels. All declared yield-model keys receive `index_curve`;
+incompatible requirements (such as an FX model) are rejected.
+
+Pass an explicit model store for distinct index curves, FX conversion, or custom
+contracts. For sensitivities with custom model wiring, use a valuation closure
+that builds this store from the bumped named curves.
 """
-reproject(c::FinanceCore.AbstractContract, index) =
-    isempty(_contract_keys(c)) ? c :
-    FinanceModels.Projection(c, Dict(k => index for k in _contract_keys(c)), FinanceModels.CashflowProjection())
+reproject(c, index::AYM) = FinanceModels.Projection(c; index)
+reproject(c, models) = FinanceModels.Projection(c, models)
 
 # value of a contract/portfolio under a single curve (coupons + discount = curve) …
 _cvalue(c::FinanceCore.AbstractContract, curve) = FinanceCore.present_value(curve, reproject(c, curve))
@@ -1553,11 +1553,8 @@ the model price equals `market_price`, with coupons estimated on `forward` (held
 Returns the spread and its sensitivity (\\\$/1bp parallel move of `credit + s`). Newton + AD.
 """
 function zspread(contract::FinanceCore.AbstractContract, credit::AYM, market_price; forward::AYM = credit, s0 = 0.0, tol = 1.0e-12, maxiter = 100)
-    ks = _contract_keys(contract)
-    pvs(s) = let disc = credit + ((z, t) -> z + FinanceCore.Continuous(s))
-        isempty(ks) ? FinanceCore.present_value(disc, contract) :
-            FinanceCore.present_value(disc, FinanceModels.Projection(contract, Dict(k => forward for k in ks), FinanceModels.CashflowProjection()))
-    end
+    projected = reproject(contract, forward)
+    pvs(s) = FinanceCore.present_value(credit + ((z, t) -> z + FinanceCore.Continuous(s)), projected)
     f(s) = pvs(s) - market_price
     s = float(s0)
     converged = false

--- a/test/projection_models.jl
+++ b/test/projection_models.jl
@@ -1,0 +1,50 @@
+@testset "FinanceModels-owned projection wiring" begin
+    index = FM.Yield.Spline(FM.Spline.Linear(), [1.0, 2.0, 5.0, 10.0], [0.02, 0.025, 0.04, 0.045])
+    credit = FM.Yield.Constant(FC.Continuous(0.06))
+    tenors = [1.0, 2.0, 5.0, 10.0]
+    fixed = FM.Bond.Fixed(0.05, FC.Periodic(2), 5.0)
+    floater = FM.Bond.Floating(0.005, FC.Periodic(2), 5.0, :index)
+    swap = FM.InterestRateSwap(index, 5.0; model_key = :index)
+    forward = FM.Forward(1.0, floater)
+    # The swap's floating leg is an Eduction; exercise it as a root too.
+    transformed = swap.b
+    portfolio = [fixed, swap, forward]
+    store = Dict(:index => index)
+    for c in (fixed, floater, swap, forward, transformed, portfolio)
+        projected = reproject(c, index)
+        @test projected isa FM.Projection
+        @test collect(projected) == collect(FM.Projection(c, store))
+        @test FC.pv(credit, projected) ≈ FC.pv(credit, FM.Projection(c, store))
+        @test reproject(c, store).model === store
+    end
+    for c in (floater, swap, forward, portfolio)
+        explicit(cs) = FC.pv(cs.credit, FM.Projection(c, Dict(:index => cs.index)))
+        reference = sensitivities(explicit, (; index, credit); tenors)
+        actual = sensitivities(c, index, credit, tenors)
+        @test actual.value ≈ reference.value
+        @test actual.forward_key_rate ≈ reference.key_rate.index
+        @test actual.spread_key_rate ≈ reference.key_rate.credit
+        @test actual.effective_dv01 ≈ reference.dv01.index + reference.dv01.credit atol = 1.0e-12
+    end
+    for c in (floater, swap, forward)
+        spread = 0.007
+        disc = credit + FC.Continuous(spread)
+        target = FC.pv(disc, FM.Projection(c, store))
+        solved = zspread(c, credit, target; forward = index)
+        @test solved.zspread ≈ spread atol = 1.0e-10
+        @test solved.zspread_dv01 ≈
+            -ForwardDiff.derivative(s -> FC.pv(credit + FC.Continuous(s), FM.Projection(c, store)), spread) / 10_000
+    end
+
+    other = FM.Bond.Floating(0.0, FC.Periodic(2), 5.0, :other)
+    pair = FC.Composite(floater, other)
+    models = Dict(:index => index, :other => credit)
+    @test FC.pv(credit, reproject(pair, models)) ≈
+        FC.pv(credit, FM.Projection(floater, models)) + FC.pv(credit, FM.Projection(other, models))
+    fx_pair = FM.FX.Pair(:EUR, :USD)
+    converted = FM.FX.Converted(floater, fx_pair, :fx)
+    fx = FM.FX.Forwards(fx_pair, 1.08, credit, index)
+    @test_throws "explicit model store" reproject(converted, index)
+    fx_models = Dict(:index => index, :fx => fx)
+    @test FC.pv(credit, reproject(converted, fx_models)) ≈ 1.08 * FC.pv(index, reproject(floater, index))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,7 @@ include("key_rate_durations.jl")
 include("sensitivities.jl")
 include("stochastic_sensitivities.jl")
 include("contract_sensitivities.jl")
+include("projection_models.jl")
 
 using Aqua
 @testset "Aqua.jl" begin


### PR DESCRIPTION
AU's private `_contract_keys` traversal misses FinanceModels' transformed swap leg, so reprojection and contract sensitivities fail on a package-provided interest-rate swap. It also duplicates model-store construction in `zspread`.

Delegate `reproject(contract, index_curve)` to FinanceModels' `Projection(contract; index)` constructor and delete the private contract traversal. Add the explicit-model-store form `reproject(contract, models)` for distinct index curves, FX, and custom contracts. `zspread` now uses the same projection boundary and holds that projection fixed while solving the discount spread.

`reproject` consistently returns a Projection, including fixed contracts. Custom single-index contracts must declare their requirements in FinanceModels; explicit stores and valuation closures remain available for custom wiring.

Dependency / merge prerequisite:
- Depends on https://github.com/JuliaActuary/FinanceModels.jl/pull/310 (tested at `9c5652efb6a21d072ce41b7f7efe18f00743c6c3`).
- Kept as a draft until that API is merged and released. Before merging AU, set `Project.toml`'s FinanceModels lower bound to the actual release containing the API, then run the normal and downgrade CI. No unreleased version number is guessed, and ordinary CI against registered FinanceModels is expected to fail until this prerequisite is satisfied.

Validation:
- Full AU suite passes on Julia 1.12.5 against the FM dependency commit (904 assertions), including Aqua.
- 49 focused assertions pass on Julia 1.10.10 and 1.12.5 against that commit: swaps, forward-starting floaters, transformed legs, portfolios, explicit distinct index/FX stores, key-rate sensitivities versus explicit valuation closures, and nonzero z-spread round trips.
- Runic formatting and `git diff --check` pass.

Addresses the AU side of shared review finding #3. Independent AU branch against `master`; no other AU review PR is required.
