### PR TITLE
Establish risk-parameter domains in constructors

### DIFF
--- a/docs/src/risk_measures.md
+++ b/docs/src/risk_measures.md
@@ -118,6 +118,21 @@ Two definitions are fixed by this framework and by this package:
 - `VaR(α)` is the lower generalized inverse: $\mathrm{VaR}_\alpha(X) = \inf\{x : F_X(x) \ge \alpha\}$. At an atom, the lower quantile applies: `VaR(0.5)(Bernoulli(0.5)) == 0`.
 - `CTE(α)` is the expected shortfall (average Value at Risk): the mean of exactly the worst $1-\alpha$ of probability mass. When the $\alpha$ boundary falls inside an atom, that atom contributes fractional weight. CTE's atom handling does not depend on the VaR boundary convention.
 
+The constructors establish the parameter domains before a measure is applied to
+an array or distribution:
+
+| Measure | Domain | Endpoint behavior |
+|:--|:--|:--|
+| `VaR(α)` | `0 ≤ α < 1` | At zero, the sample minimum or `quantile(risk, 0)` (`-Inf` for support unbounded below). One is excluded. |
+| `CTE(α)` | `0 ≤ α < 1` | At zero, the mean with the same conventions as `Expectation()`. One is excluded because the tail has zero probability mass. |
+| `WangTransform(α)` | `0 < α < 1` | Both endpoints are excluded so that `Φ⁻¹(α)` is finite. At `α = 0.5`, the distortion is the identity. |
+
+Out-of-domain real parameters, including `NaN` and infinities, throw
+`ArgumentError` at construction. Explicitly typed constructors, such as
+`CTE{Float32}(α)`, validate the converted value; a value that rounds to one is
+rejected. `ValueAtRisk` and `ConditionalTailExpectation` are aliases and follow
+the same rules.
+
 !!! note "How the computation is performed"
     The implementation picks the most exact path available, in this order:
 

--- a/docs/src/upgrade.md
+++ b/docs/src/upgrade.md
@@ -1,5 +1,19 @@
 # Version Upgrade Guide
 
+## Unreleased
+
+`VaR` and `CTE` now enforce their documented domain `0 ≤ α < 1` at construction,
+including through the `ValueAtRisk` and `ConditionalTailExpectation` aliases and
+explicitly typed constructors. `WangTransform` requires `0 < α < 1`; its earlier
+documentation incorrectly included the endpoints. Out-of-domain real values
+(including `NaN` and infinities) throw `ArgumentError`. Explicitly typed
+constructors validate the value after conversion.
+
+At zero, `VaR` remains the essential infimum and `CTE` remains the mean. One is
+excluded for both measures, and both endpoints are excluded for `WangTransform`.
+This establishes behavior for invalid parameters; it does not change results
+at valid confidence levels.
+
 ## v5.11.1 to v5.11.2
 
 This release fixes a class of bugs where risk measures returned believable but wrong finite numbers. Two behavior changes matter for existing code.

--- a/src/risk_measures.jl
+++ b/src/risk_measures.jl
@@ -92,7 +92,11 @@ return a more positive number.
 `VaR(α)` returns a functor which can then be called on a risk distribution.
 
 ## Parameters
-- α: [0,1.0)
+- `α` is a real confidence level in `0 ≤ α < 1`. Real values outside this
+  domain, including `NaN` and infinities, throw `ArgumentError` at construction.
+  `α = 0` selects the essential infimum as described above.
+  `α = 1` is excluded; no upper-endpoint extension is defined.
+  Explicitly typed constructors check the value after conversion to that type.
 
 ## Examples
 
@@ -109,7 +113,14 @@ julia> rm(rand(1000))
 """
 struct VaR{T <: Real} <: RiskMeasure
     α::T
+
+    function VaR{T}(α) where {T <: Real}
+        α = convert(T, α)
+        0 <= α < 1 || throw(ArgumentError("α must be in [0, 1), got $α"))
+        return new{T}(α)
+    end
 end
+VaR(α::T) where {T <: Real} = VaR{T}(α)
 # The boundary uses `<=` so that the Choquet form of this distortion selects the
 # lower quantile at an atom, matching `Distributions.quantile`.
 g(rm::VaR, x) = x <= (1 - rm.α) ? 0 : 1
@@ -149,7 +160,11 @@ CTE(α) returns a functor which can then be called on a risk distribution.
 
 ## Parameters
 
-- α: [0,1.0)
+- `α` is a real confidence level in `0 ≤ α < 1`. Real values outside this
+  domain, including `NaN` and infinities, throw `ArgumentError` at construction.
+  `α = 0` gives the mean. `α = 1` is excluded because the
+  averaged tail would have zero probability mass; no limiting value is used.
+  Explicitly typed constructors check the value after conversion to that type.
 
 ## Examples
 
@@ -166,7 +181,14 @@ julia> rm(rand(1000))
 """
 struct CTE{T <: Real} <: RiskMeasure
     α::T
+
+    function CTE{T}(α) where {T <: Real}
+        α = convert(T, α)
+        0 <= α < 1 || throw(ArgumentError("α must be in [0, 1), got $α"))
+        return new{T}(α)
+    end
 end
+CTE(α::T) where {T <: Real} = CTE{T}(α)
 g(rm::CTE, x) = x < (1 - rm.α) ? x / (1 - rm.α) : 1
 gbar(rm::CTE, F) = F <= rm.α ? zero(F / (1 - rm.α)) : (F - rm.α) / (1 - rm.α)
 
@@ -188,7 +210,11 @@ numerical quadrature. That path throws an error when the defining integral
 cannot be verified to converge, for example for heavy-tailed risks.
 
 ## Parameters
-- α: [0,1.0]
+- `α` is a real parameter in `0 < α < 1`. Real values outside this domain,
+  including `NaN` and infinities, throw `ArgumentError` at construction.
+  Both endpoints are excluded because `Φ⁻¹(α)` must be finite.
+  `α = 0.5` gives the identity distortion and hence the expectation.
+  Explicitly typed constructors check the value after conversion to that type.
 
 In the literature, sometimes λ is used where ``\\lambda = \\Phi^{-1}(\\alpha)``.
 
@@ -209,9 +235,16 @@ julia> rm(rand(1000))
 ## References
 - "A Risk Measure That Goes Beyond Coherence", Shaun S. Wang, 2002
 """
-struct WangTransform{T} <: RiskMeasure
+struct WangTransform{T <: Real} <: RiskMeasure
     α::T
+
+    function WangTransform{T}(α) where {T <: Real}
+        α = convert(T, α)
+        0 < α < 1 || throw(ArgumentError("α must be in (0, 1), got $α"))
+        return new{T}(α)
+    end
 end
+WangTransform(α::T) where {T <: Real} = WangTransform{T}(α)
 function g(rm::WangTransform, x)
     Φ_inv(x) = Distributions.quantile(Distributions.Normal(), x)
     return Distributions.cdf(Distributions.Normal(), Φ_inv(x) + Φ_inv(rm.α))

--- a/test/risk_measures.jl
+++ b/test/risk_measures.jl
@@ -22,6 +22,62 @@ Distributions.ccdf(::DelayedDirac, x::Real) = x < 100 ? 1.0 : 0.0
 
 @testset "Risk Measures" begin
 
+    @testset "Parameter domains" begin
+        for Measure in (VaR, ValueAtRisk, CTE, ConditionalTailExpectation, WangTransform)
+            for α in (-Inf, -0.5, prevfloat(0.0), 1, nextfloat(1.0), Inf, NaN)
+                @test_throws ArgumentError Measure(α)
+                @test_throws ArgumentError Measure{Float64}(α)
+            end
+            for α in (0.5f0, 0.5, big"0.5", 1 // 2)
+                @test Measure(α).α === α
+            end
+            @test Measure{Float32}(0.5).α === 0.5f0
+            @test Measure{Real}(0.5) isa Measure{Real}
+            # Conversion must not create an unchecked endpoint value.
+            @test_throws ArgumentError Measure{Float32}(prevfloat(1.0))
+            @test Measure(prevfloat(1.0)).α == prevfloat(1.0)
+        end
+        for Measure in (VaR, CTE)
+            @test Measure(0).α === 0
+            @test Measure(-0.0).α === -0.0
+            @test Measure(nextfloat(0.0)).α == nextfloat(0.0)
+        end
+        @test_throws ArgumentError WangTransform(0)
+        @test_throws ArgumentError WangTransform(-0.0)
+        @test_throws ArgumentError WangTransform{Float64}(0)
+        @test_throws ArgumentError WangTransform{Float32}(nextfloat(0.0))
+        @test WangTransform(nextfloat(0.0)).α == nextfloat(0.0)
+    end
+
+    @testset "Confidence levels on samples and discrete laws" begin
+        # Repeated outcomes, both signs, and exact atom boundaries. The
+        # distribution aggregates the same eight equally weighted observations.
+        sample = [2.0, -3.0, 9.0, 2.0, 0.0, -3.0, 5.0, 2.0]
+        d = DiscreteNonParametric([-3.0, 0.0, 2.0, 5.0, 9.0], [2, 1, 3, 1, 1] ./ 8)
+        levels = vcat(
+            collect(0.0:0.03125:0.96875),
+            nextfloat(0.0), prevfloat(1.0),
+            [f(α) for α in (0.25, 0.375, 0.75, 0.875) for f in (prevfloat, nextfloat)],
+        )
+        for α in levels, Measure in (VaR, CTE)
+            rm = Measure(α)
+            @test rm(sample) ≈ rm(d) atol = 1.0e-14
+            @test rm(reshape(sample, 2, 4)) ≈ rm(d) atol = 1.0e-14
+        end
+        @test VaR(0)(sample) == VaR(0)(d) == -3
+        @test CTE(0)(sample) ≈ CTE(0)(d) ≈ mean(sample)
+        @test VaR(0.75)(sample) == VaR(0.75)(d) == 2
+        @test VaR(nextfloat(0.75))(sample) == VaR(nextfloat(0.75))(d) == 5
+        @test CTE(0.5)(sample) ≈ CTE(0.5)(d) ≈ 4.5
+        for Measure in (VaR, CTE)
+            @test Measure(prevfloat(1.0))(sample) == Measure(prevfloat(1.0))(d) == 9
+        end
+        for α in (nextfloat(0.0), 0.01, 0.5, 0.99, prevfloat(1.0))
+            @test WangTransform(α)(sample) ≈ WangTransform(α)(d)
+        end
+        @test WangTransform(0.5)(sample) ≈ WangTransform(0.5)(d) ≈ mean(sample)
+    end
+
     for bad in (0, -1, Inf, NaN)
         @test_throws ArgumentError DualPower(bad)
         @test_throws ArgumentError ProportionalHazard(bad)


### PR DESCRIPTION
After #155 removed constructor checks, VaR and CTE accepted parameters outside their documented domain and evaluation behavior depended on the risk representation. Establish the domain once in constructors: `0 ≤ α < 1` for VaR/CTE and `0 < α < 1` for WangTransform. Invalid real parameters, including NaN and infinities, throw `ArgumentError`; explicitly typed constructors validate after conversion.

Document deliberate endpoint behavior: VaR(0) is the essential infimum, CTE(0) is the mean, and α = 1 is excluded for both. Correct WangTransform’s documentation to exclude both endpoints. Valid confidence-level calculations remain unchanged.

Add coverage for aliases, typed construction, conversion rounding to excluded endpoints, and sample/discrete-distribution agreement across valid levels and atom boundaries. This independently addresses the parameter-domain portion of the #155 finding and applies cleanly alongside #159.

Validation:
- Full suite: 1,157 assertions passed on Julia 1.10.10 and 1.12.5, including Aqua.
- Combined with #159: all 576 risk-measure, optimal-transport, and finite-discrete-transport assertions passed.
- Runic and `git diff --check` passed.
